### PR TITLE
Study page action sheets

### DIFF
--- a/app/assets/stylesheets/_action-sheet.scss
+++ b/app/assets/stylesheets/_action-sheet.scss
@@ -1,0 +1,106 @@
+// Styling for the "action sheets" currently
+// only displayed on the study page.
+
+.action-sheet {
+  margin-top: 1em;
+  background-color: $color-pale-toffee;
+  border-radius: 0.3em;
+
+  select, input[type="text"], textarea {
+    width: 100%;
+  }
+
+  @media (min-width: $screen-sm-min) {
+    p {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.action-sheet__section {
+  padding: 1.5em;
+}
+
+.action-sheet__section--child {
+  background-color: $color-mid-toffee;
+  padding-left: 4em;
+  margin: 0.5em 0;
+
+  // Vertical space between rows in this section
+  p + p,
+  .row p {
+    margin-top: 1em;
+  }
+
+  // No space above first row in this section
+  & > .row:first-child p {
+    margin-top: 0;
+  }
+}
+
+.action-sheet__section--last {
+  border-top: 1px solid $color-mid-toffee;
+}
+
+.action-sheet__warning {
+  font-size: 0.875em; // 14px
+  color: $color-dark-toffee;
+  line-height: 1.3em;
+}
+
+.action-sheet__submit {
+  @media (min-width: $screen-sm-min) {
+    text-align: right;
+  }
+}
+
+.output-type-accordion {
+  padding: 1em 0;
+}
+
+.output-type-input {
+  float: left;
+
+  // override Bootstrap-sass's default margin and
+  // margin-top (designed for inline checkboxes)
+  margin: 0.7em 0 0 2em !important;
+}
+
+.output-type-label {
+  display: block;
+  padding: 0.5em 1.5em 0.5em 4em;
+  margin: 0;
+}
+
+.manual-publication-details-link {
+  display: block;
+  margin: 0.5em 0 0 0;
+  font-weight: inherit;
+  color: $link-color;
+  cursor: pointer;
+
+  &:hover, &:focus {
+    color: $link-hover-color;
+    text-decoration: $link-hover-decoration;
+  }
+
+  // Cleverly position the DOI link to the right of the DOI input
+  @media (min-width: $screen-sm-min) {
+    position: absolute;
+    right: -100%;
+    width: 100%;
+    bottom: 0.5em;
+    margin-top: 0;
+  }
+}
+
+.other-impact-type {
+  input[type="checkbox"] {
+    margin: 0 0.5em 0 0;
+    vertical-align: 1px;
+  }
+
+  textarea {
+    margin-top: 0.5em;
+  }
+}

--- a/app/assets/stylesheets/_houdini.scss
+++ b/app/assets/stylesheets/_houdini.scss
@@ -1,0 +1,46 @@
+// Houdini is a custom-written CSS+HTML library for
+// showing and hiding elements on a page using just
+// checkboxes and radio buttons.
+
+// Relies on the "+" adjacent/next sibling selector and
+// the ":checked" pseudo-class, which means this doesn't
+// work in IE8 or below.
+
+// Example use:
+//
+// <label class="houdini-label" for="input1">Click me...</label>
+// <input class="houdini-input" type="checkbox" id="input1">
+// <div class="houdini-target">...To show and hide me</div>
+
+// Or an example where the input remains visible to the user,
+// and is placed before the label (eg: to be floated right, so it
+// appears to the right of the label, like a normal checkbox):
+//
+// <input class="houdini-input houdini-input--visible" type="checkbox" id="input2">
+// <label class="houdini-label" for="input2">Click me...</label>
+// <div class="houdini-target">...To show and hide me</div>
+
+// The three elements must be placed sequentially in the document,
+// either label+input+target or input+label+target.
+
+// Each label+input pair must have matching `id` and `for` attributes.
+// You cannot nest the input inside the label.
+
+.houdini-input {
+  position: absolute;
+  opacity: 0;
+}
+
+.houdini-input--visible {
+  position: static;
+  opacity: 1;
+}
+
+.houdini-target {
+  display: none;
+
+  .houdini-input:checked + &,
+  .houdini-input:checked + .houdini-label + & {
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/_shared.scss
+++ b/app/assets/stylesheets/_shared.scss
@@ -26,3 +26,7 @@ body {
 .site-footer {
   background-color: $color-light-blue;
 }
+
+.btn-success {
+  text-shadow: 0 1px 1px $color-semi-transparent-shadow-darker;
+}

--- a/app/assets/stylesheets/_study-main.scss
+++ b/app/assets/stylesheets/_study-main.scss
@@ -15,7 +15,11 @@
 
   ul {
     @extend .list-inline;
-    margin: 0;
+    margin: 0 -5px; // compensate for 5px padding on children
+  }
+
+  .action-sheet {
+    max-width: (40em * 0.875) + 2; // Line up right edge with blockquotes in timeline
   }
 }
 
@@ -103,7 +107,7 @@
 .timeline__item__note {
   border-left: 0;
   font-size: 0.875em; // 14px
-  max-width: 35em;
+  max-width: 40em;
   padding: 1em 1.3em;
   background-color: $color-lighter-blue;
   border-radius: 0.3em;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -11,6 +11,7 @@ $color-platinum-white: #F0EEEF;
 $color-silver-white: #E6E6E6;
 
 $color-semi-transparent-shadow: rgba(0, 0, 0, 0.1);
+$color-semi-transparent-shadow-darker: rgba(0, 0, 0, 0.3);
 $color-light-grey: #AAA;
 $color-mid-grey: #999;
 $color-mid-grey-alternate: #9B9B9B;
@@ -42,3 +43,5 @@ $headings-font-weight: bold;
 $btn-default-bg: $color-off-white;
 $btn-default-color: $color-dark-grey;
 $btn-default-border: $color-silver-white;
+$btn-success-bg: #79BB2F;
+$btn-success-border: #64A31E;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -21,6 +21,8 @@
 // specific files when we know what we're using.
 @import "bootstrap";
 
+@import "houdini";
+
 @import "shared";
 @import "alert";
 @import "nav";
@@ -31,3 +33,4 @@
 @import "list-of-things";
 @import "study-main";
 @import "auth";
+@import "action-sheet";

--- a/app/views/studies/_study_actions.html.erb
+++ b/app/views/studies/_study_actions.html.erb
@@ -1,0 +1,179 @@
+<ul>
+    <li>
+        <label class="btn btn-default houdini-label" for="add-document">Add a document</label>
+    </li>
+    <li>
+        <label class="btn btn-default houdini-label" for="add-note">Add a note</label>
+    </li>
+    <li>
+        <label class="btn btn-default houdini-label" for="record-output">Record an output</label>
+    </li>
+</ul>
+
+<input class="houdini-input" type="radio" name="action-sheet-accordion" id="add-document">
+
+<form class="action-sheet houdini-target">
+    <div class="action-sheet__section">
+        <div class="row">
+            <p class="col-sm-7">
+                <label for="document-choose">Choose document:</label>
+                <input type="file" id="document-choose">
+            </p>
+            <p class="col-sm-5">
+                <label for="document-type">Document type:</label>
+                <select class="form-control" id="document-type">
+                  <% ["Protocol", "ERB documentation", "Data sharing agreements", "Dataset", "Study report", "Other"].each do |x| %>
+                    <option><%= x %></option>
+                  <% end %>
+                </select>
+            </p>
+        </div>
+    </div>
+    <div class="action-sheet__section action-sheet__section--last">
+        <div class="row">
+            <p class="col-sm-7 action-sheet__warning">
+                <strong>Remember:</strong><br>
+                This document will be publicly accessible
+            </p>
+            <p class="col-sm-5 action-sheet__submit">
+                <button class="btn btn-success">Add document</button>
+            </p>
+        </div>
+    </div>
+</form>
+
+<input class="houdini-input" type="radio" name="action-sheet-accordion" id="add-note">
+
+<form class="action-sheet houdini-target">
+    <div class="action-sheet__section">
+        <div class="row">
+            <p class="col-sm-12">
+                <label for="note-content">Note:</label>
+                <textarea id="note-content" class="form-control"></textarea>
+            </p>
+        </div>
+    </div>
+    <div class="action-sheet__section action-sheet__section--last">
+        <div class="row">
+            <p class="col-sm-7 action-sheet__warning">
+                <strong>Remember:</strong><br>
+                This note will be publicly accessible
+            </p>
+            <p class="col-sm-5 action-sheet__submit">
+                <button class="btn btn-success">Add note</button>
+            </p>
+        </div>
+    </div>
+</form>
+
+<input class="houdini-input" type="radio" name="action-sheet-accordion" id="record-output">
+
+<form class="action-sheet houdini-target">
+    <div class="output-type-accordion">
+
+        <input type="radio" name="output-type" id="output-type-publication" class="output-type-input houdini-input houdini-input--visible">
+        <label for="output-type-publication" class="output-type-label houdini-label">
+            Publication
+        </label>
+
+        <div class="action-sheet__section action-sheet__section--child houdini-target">
+            <div class="row">
+                <p class="col-sm-6">
+                    <label for="publication-doi">DOI:</label>
+                    <input type="text" class="form-control" id="publication-doi">
+                    <label for="manual-publication-details" class="manual-publication-details-link houdini-label">Or enter details manually&hellip;</label>
+                </p>
+            </div>
+
+            <input type="checkbox" class="houdini-input" id="manual-publication-details">
+            <div class="houdini-target">
+                <div class="row">
+                    <p class="col-sm-6">
+                        <label for="article_title">Article title:</label>
+                        <input type="text" class="form-control" id="article_title">
+                    </p>
+                    <p class="col-sm-6">
+                        <label for="lead_author">Lead author:</label>
+                        <input type="text" class="form-control" id="lead_author">
+                    </p>
+                </div>
+                <div class="row">
+                    <p class="col-sm-6">
+                        <label for="book_or_journal_title">Publication title:</label>
+                        <input type="text" class="form-control" id="book_or_journal_title">
+                    </p>
+                    <p class="col-sm-6">
+                        <label for="publication_year">Publication year:</label>
+                        <input type="text" class="form-control" id="publication_year">
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <input type="radio" name="output-type" id="output-type-dissemination" class="output-type-input houdini-input houdini-input--visible">
+        <label for="output-type-dissemination" class="output-type-label houdini-label">
+            Dissemination
+        </label>
+
+        <div class="action-sheet__section action-sheet__section--child houdini-target">
+            <p>
+                <label for="dissemination_category">Category:</label>
+                <select class="form-control" id="dissemination_category">
+                    <optgroup label="Internal">
+                        <option>Working group</option>
+                        <option>Internal MSF publication</option>
+                        <option>MSF conference</option>
+                        <option>Email group</option>
+                    </optgroup>
+                    <optgroup label="External">
+                        <option>Field</option>
+                        <option>Scientific meeting</option>
+                        <option>Press release or press conference</option>
+                        <option>Talk or presentation</option>
+                        <option>Policy briefing paper</option>
+                        <option>Formal working group, expert panel, advisory body</option>
+                        <option>Magazine, newsletter or online publication</option>
+                        <option>Bilateral meeting</option>
+                        <option>Community involved with research</option>
+                    </optgroup>
+                    <option>Other</option>
+                </select>
+            </p>
+            <p>
+                <label for="dissemination_details">Details</label>
+                <textarea id="dissemination_details" class="form-control"></textarea>
+            </p>
+            <p>
+                <label class="checkbox-inline"><input type="checkbox"> This has been fed back to the field</label>
+            </p>
+        </div>
+
+        <input type="radio" name="output-type" id="output-type-other" class="output-type-input houdini-input houdini-input--visible">
+        <label for="output-type-other" class="output-type-label houdini-label">
+            Other impact
+        </label>
+
+        <div class="action-sheet__section action-sheet__section--child houdini-target">
+          <% ['Programmes', 'Patients', 'MSF policy', 'External policy', 'Other'].each do |x| %>
+            <p class="other-impact-type">
+                <input type="checkbox" class="houdini-input houdini-input--visible" id="impact_type_<%= x.parameterize %>">
+                <label class="houdini-label" for="impact_type_<%= x.parameterize %>"><%= x %></label>
+                <textarea class="form-control houdini-target" placeholder="Description&hellip;"></textarea>
+            </p>
+          <% end %>
+        </div>
+
+    </div>
+
+    <div class="action-sheet__section action-sheet__section--last">
+        <div class="row">
+            <p class="col-sm-7 action-sheet__warning">
+                <strong>Remember:</strong><br>
+                This output will be publicly accessible
+            </p>
+            <p class="col-sm-5 action-sheet__submit">
+                <button class="btn btn-success">Add output</button>
+            </p>
+        </div>
+    </div>
+</form>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -61,17 +61,7 @@
         <div class="study-main">
             <div class="study-main__primary">
                 <div class="study-main__actions">
-                    <ul>
-                        <li>
-                            <a class="btn btn-default">Add a document</a>
-                        </li>
-                        <li>
-                            <a class="btn btn-default">Add a note</a>
-                        </li>
-                        <li>
-                            <a class="btn btn-default">Record an output</a>
-                        </li>
-                    </ul>
+                    <%= render "study_actions" %>
                 </div>
                 <div class="study-main__timeline timeline">
                     <ol reversed>

--- a/config/linters/scss.yml
+++ b/config/linters/scss.yml
@@ -79,7 +79,7 @@ linters:
     enabled: true
 
   ImportantRule:
-    enabled: true
+    enabled: false
 
   ImportPath:
     enabled: true
@@ -147,8 +147,8 @@ linters:
 
   QualifyingElement:
     enabled: true
-    allow_element_with_attribute: false
-    allow_element_with_class: false
+    allow_element_with_attribute: true
+    allow_element_with_class: true
     allow_element_with_id: false
 
   SelectorDepth:


### PR DESCRIPTION
Part of #3.

Styling and markup for the "Add a document" / "Add a note" etc buttons and forms on the study page.

All done with checkboxes and radio buttons, rather than javascript, which is cute:

![action-sheet](https://cloud.githubusercontent.com/assets/739624/12294623/d1bd4244-b9f3-11e5-8b8a-714cc34aa0bf.gif)

Once this is merged, we'll probably want to upgrade the nav bar mobile show/hide behaviour to use Houdini, for consistency.