### PR TITLE
Drop user roles in favour of an is_admin flag

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,10 +1,10 @@
 ActiveAdmin.register User do
-  permit_params :name, :email, :role, :msf_location_id, :external_location,
+  permit_params :name, :email, :is_admin, :msf_location_id, :external_location,
                 :password, :password_confirmation
 
   menu priority: 2
 
-  filter :role, as: :select, collection: User.roles
+  filter :is_admin
   filter :msf_location
   filter :created_at
 
@@ -14,7 +14,7 @@ ActiveAdmin.register User do
     column :email
     column :msf_location
     column :external_location
-    column :role
+    column :is_admin
     column :created_at
     column :last_sign_in_at
 
@@ -29,7 +29,7 @@ ActiveAdmin.register User do
       f.input :external_location, as: :string
       f.input :password
       f.input :password_confirmation
-      f.input :role, as: :select, collection: User.roles
+      f.input :is_admin
     end
     f.actions
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   def authenticate_admin_user!
     if !current_user
       redirect_to new_user_session_path
-    elsif !current_user.admin?
+    elsif !current_user.is_admin
       render status: :forbidden,
              text: "Sorry, you don't have access to this page"
     end
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
   # Redirect admins to the admin dashboard
   def after_sign_in_path_for(resource)
     stored_location_for(resource) ||
-      if resource.is_a?(User) && resource.admin?
+      if resource.is_a?(User) && resource.is_admin
         admin_dashboard_path
       else
         root_path

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -68,34 +68,12 @@ class Study < ActiveRecord::Base
   validates :study_topic, presence: true
   validates :protocol_needed, inclusion: { in: [true, false] }
   validate :other_study_type_is_set_when_study_type_is_other
-  validate :principal_investigator_has_correct_role
-  validate :research_manager_has_correct_role
 
   def other_study_type_is_set_when_study_type_is_other
     if study_type == StudyType.other_study_type && other_study_type.blank?
       message = "You must describe the study type if you choose " \
         "\"#{StudyType::OTHER_STUDY_TYPE_NAME}\""
       errors.add(:other_study_type, message)
-    end
-  end
-
-  def principal_investigator_has_correct_role
-    return if principal_investigator.blank?
-
-    message = "The Principal Investigator for this Study has to have the " \
-      "Principal Investigator role"
-    unless principal_investigator.principal_investigator?
-      errors.add(:principal_investigator, message)
-    end
-  end
-
-  def research_manager_has_correct_role
-    return if research_manager.blank?
-
-    message = "The Research Manager for this Study has to have the Research" \
-      "Manager role"
-    unless research_manager.research_manager?
-      errors.add(:research_manager, message)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@
 #  msf_location_id        :integer
 #  external_location      :text
 #  role                   :enum             default("normal_user"), not null
+#  is_admin               :boolean          default(FALSE), not null
 #
 # Indexes
 #
@@ -55,7 +56,6 @@ class User < ActiveRecord::Base
            inverse_of: :research_manager
 
   validates :name, presence: true
-  validates :role, presence: true
   validate :external_location_is_set_if_msf_location_is_external
 
   def external_location_is_set_if_msf_location_is_external

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
         <footer class="site-footer">
             <div class="container">
                 <ul class="site-footer__links">
-                    <% if user_signed_in? && current_user.admin? %>
+                    <% if user_signed_in? && current_user.is_admin %>
                         <li><a href="<%= admin_dashboard_path %>">Admin panel</a></li>
                     <% end %>
                 </ul>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -169,7 +169,7 @@
                     <p>Be notified when there is activity on this study.</p>
                     <p><a href="#" class="btn btn-success">Follow this study</a></p>
                 </div>
-                <% if user_signed_in? && current_user.admin? %>
+                <% if user_signed_in? && current_user.is_admin %>
                     <div class="study-main__secondary__section study-main__secondary__section--admin">
                         <h3>Admin actions:</h3>
                         <ul>

--- a/db/migrate/20160114173551_add_is_admin_to_user.rb
+++ b/db/migrate/20160114173551_add_is_admin_to_user.rb
@@ -1,0 +1,14 @@
+class AddIsAdminToUser < ActiveRecord::Migration
+  def up
+    add_column :users, :is_admin, :boolean, null: false, default: false
+
+    User.find_each do |user|
+      user.is_admin = user.role == "admin"
+      user.save!
+    end
+  end
+
+  def down
+    remove_column :users, :is_admin
+  end
+end

--- a/db/migrate/20160114175311_remove_role_from_user.rb
+++ b/db/migrate/20160114175311_remove_role_from_user.rb
@@ -1,0 +1,13 @@
+class RemoveRoleFromUser < ActiveRecord::Migration
+  def up
+    remove_column :users, :role, :role
+
+    execute <<-SQL
+      DROP TYPE role;
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -34,19 +34,6 @@ CREATE TYPE dissemination_category_type AS ENUM (
 );
 
 
---
--- Name: role; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE role AS ENUM (
-    'principal_investigator',
-    'research_manager',
-    'admin',
-    'contributor',
-    'normal_user'
-);
-
-
 SET default_tablespace = '';
 
 SET default_with_oids = false;
@@ -671,7 +658,7 @@ CREATE TABLE users (
     name text NOT NULL,
     msf_location_id integer,
     external_location text,
-    role role DEFAULT 'normal_user'::role NOT NULL
+    is_admin boolean DEFAULT false NOT NULL
 );
 
 
@@ -1344,4 +1331,8 @@ ALTER TABLE ONLY publications
 SET search_path TO "$user",public;
 
 INSERT INTO schema_migrations (version) VALUES ('20160108112933');
+
+INSERT INTO schema_migrations (version) VALUES ('20160114173551');
+
+INSERT INTO schema_migrations (version) VALUES ('20160114175311');
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -11,16 +11,8 @@ FactoryGirl.define do
     # This makes the user full confirmed
     after :create, &:confirm
 
-    factory :principal_investigator do
-      role "principal_investigator"
-    end
-
-    factory :research_manager do
-      role "research_manager"
-    end
-
     factory :admin_user do
-      role "admin"
+      is_admin true
     end
   end
 end

--- a/spec/features/admin/user_admin_spec.rb
+++ b/spec/features/admin/user_admin_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe "UserAdmin" do
       fill_in "Password", with: "password"
     end
     fill_in "Password confirmation", with: "password"
-    select "normal_user", from: "Role"
     click_button "Create User"
     expect(page).to have_text "User was successfully created"
     user = User.find_by_name("A New User")
@@ -38,10 +37,10 @@ RSpec.describe "UserAdmin" do
 
     it "allows you to edit the user" do
       click_link "Edit", href: edit_admin_user_path(user)
-      select "admin", from: "Role"
+      check "Is admin"
       click_button "Update User"
       expect(page).to have_text "User was successfully updated"
-      expect(user.reload.role).to eq "admin"
+      expect(user.reload.is_admin).to be true
     end
 
     it "allows you to delete the user" do

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -105,32 +105,4 @@ RSpec.describe Study, type: :model do
       expect(study).to be_valid
     end
   end
-
-  context "when principal_investigator is set" do
-    it "is valid when the pi user has the pi role" do
-      pi = FactoryGirl.create(:principal_investigator)
-      study = FactoryGirl.build(:study, principal_investigator: pi)
-      expect(study).to be_valid
-    end
-
-    it "is invalid when the pi user doesn't have the pi role" do
-      normal_user = FactoryGirl.create(:normal_user)
-      study = FactoryGirl.build(:study, principal_investigator: normal_user)
-      expect(study).to be_invalid
-    end
-  end
-
-  context "when research_manager is set" do
-    it "is valid when the rm user has the rm role" do
-      pi = FactoryGirl.create(:research_manager)
-      study = FactoryGirl.build(:study, research_manager: pi)
-      expect(study).to be_valid
-    end
-
-    it "is invalid when the rm user doesn't have the rm role" do
-      normal_user = FactoryGirl.create(:normal_user)
-      study = FactoryGirl.build(:study, research_manager: normal_user)
-      expect(study).to be_invalid
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe User, type: :model do
   it { is_expected.to have_db_column(:msf_location_id).of_type(:integer) }
   it { is_expected.to have_db_column(:external_location).of_type(:text) }
   it do
-    is_expected.to have_db_column(:role).of_type(:enum).
-      with_options(null: false, default: "normal_user")
+    is_expected.to have_db_column(:is_admin).of_type(:boolean).
+      with_options(null: false, default: false)
   end
 
   # Associations
@@ -26,15 +26,7 @@ RSpec.describe User, type: :model do
 
   # Validation
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:role) }
-  expected_enum_options = {
-    principal_investigator: "principal_investigator",
-    research_manager: "research_manager",
-    admin: "admin",
-    contributor: "contributor",
-    normal_user: "normal_user",
-  }
-  it { is_expected.to define_enum_for(:role).with(expected_enum_options) }
+  it { is_expected.to validate_inclusion_of(:is_admin).in_array([true, false]) }
 
   context "when the when msf_location field is 'External'" do
     let(:external_location) { MsfLocation.find_by_name("External") }

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "home/index.html.erb", type: :view do
   end
 
   it "shows the PI when there is one" do
-    pi = FactoryGirl.create(:principal_investigator)
+    pi = FactoryGirl.create(:user)
     @studies.first.principal_investigator = pi
     @studies.first.save!
     render


### PR DESCRIPTION
As the commit message says - @davea pointed out that the user roles were an
unnecessary complication, so this PR removes them.