### PR TITLE
Make ERB Status required if studies have been or are going through ERB

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -91,6 +91,7 @@ class Study < ActiveRecord::Base
   validates :study_type, presence: true
   validates :study_setting, presence: true
   validates :study_topics, presence: true
+  validates :erb_status, presence: true, if: :erb_status_needed?
   validates :protocol_needed, inclusion: { in: [true, false] }
   validate :other_study_type_is_set_when_study_type_is_other
 
@@ -198,5 +199,10 @@ class Study < ActiveRecord::Base
     unless study_topics.empty?
       study_topics.map(&:name).to_sentence
     end
+  end
+
+  # Is the study at a stage where we need to have an erb_status selected?
+  def erb_status_needed?
+    protocol_needed && !(concept? || withdrawn_postponed?)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -102,6 +102,7 @@ StudySetting.create(
 ErbStatus.create(
   [
     { name: "Exempt" },
+    { name: "In draft" },
     { name: "Submitted" },
     { name: "Reject" },
     { name: "Re-review" },

--- a/lib/tasks/load_msf_spreadsheet.rake
+++ b/lib/tasks/load_msf_spreadsheet.rake
@@ -74,6 +74,9 @@ task :load_msf_spreadsheet, [:csv_file] => [:environment] do |_t, args|
       status = row[:erb_status]
       status = "Submitted" if status == "In submission"
       erb_status = ErbStatus.find_by_name(status)
+      if erb_status.blank?
+        erb_status = ErbStatus.find_by_name("In draft")
+      end
       protocol_needed = true
     end
 

--- a/spec/factories/erb_status.rb
+++ b/spec/factories/erb_status.rb
@@ -2,15 +2,22 @@ FactoryGirl.define do
   factory :erb_status, aliases: [:exempt_status] do
     name "Exempt"
 
+    factory :in_draft do
+      name "In draft"
+    end
+
     factory :submitted do
       name "Submitted"
     end
+
     factory :reject do
       name "Reject"
     end
+
     factory :rereview do
       name "Re-review"
     end
+
     factory :accept do
       name "Accept"
     end

--- a/spec/features/admin/study_admin_spec.rb
+++ b/spec/features/admin/study_admin_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe "StudyAdmin" do
   end
 
   context "with an existing study" do
+    let!(:accept_status) { FactoryGirl.create(:accept) }
     let!(:study) { FactoryGirl.create(:study) }
 
     before do
@@ -108,9 +109,11 @@ RSpec.describe "StudyAdmin" do
     it "allows you to edit the study" do
       click_link "Edit", href: edit_admin_study_path(study)
       select Study::STUDY_STAGE_LABELS[:protocol_erb], from: "Study stage"
+      select accept_status.name, from: "Erb status"
       click_button "Update Study"
       expect(page).to have_text "Study was successfully updated"
       expect(study.reload.study_stage).to eq "protocol_erb"
+      expect(study.reload.erb_status).to eq accept_status
     end
 
     it "allows you to delete the study" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe "#study_timeline" do
+    let(:accept_status) { FactoryGirl.create(:accept) }
     let(:base_timeline) do
       {
         concept: { label: "Concept", state: "" },
@@ -24,7 +25,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       context "when the study is in the protocol_erb stage" do
-        let(:study) { FactoryGirl.create(:study, study_stage: "protocol_erb") }
+        let(:study) do
+          FactoryGirl.create(:study, study_stage: "protocol_erb",
+                                     erb_status: accept_status)
+        end
 
         it "returns a timeline with multiple entries" do
           expected_timeline = base_timeline
@@ -35,7 +39,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
 
       context "when the study is in the completion stage" do
-        let(:study) { FactoryGirl.create(:study, study_stage: "completion") }
+        let(:study) do
+          FactoryGirl.create(:study, study_stage: "completion",
+                                     erb_status: accept_status)
+        end
 
         it "returns a timeline with multiple entries" do
           expected_timeline = base_timeline
@@ -91,6 +98,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
         it "returns a timeline with multiple entries" do
           study.study_stage = "protocol_erb"
+          study.erb_status = accept_status
           study.save!
 
           expected_timeline = base_timeline
@@ -105,6 +113,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
         it "returns a timeline with multiple entries" do
           study.study_stage = "protocol_erb"
+          study.erb_status = accept_status
           study.save!
           study.study_stage = "delivery"
           study.save!
@@ -128,6 +137,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
         it "returns a timeline with multiple entries" do
           study.study_stage = "protocol_erb"
+          study.erb_status = accept_status
           study.save!
           study.study_stage = "delivery"
           study.save!
@@ -150,6 +160,7 @@ RSpec.describe ApplicationHelper, type: :helper do
 
         it "returns a timeline with entries only for completed stages" do
           study.study_stage = "protocol_erb"
+          study.erb_status = accept_status
           study.save!
           study.study_stage = "delivery"
           study.save!

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -90,6 +90,31 @@ RSpec.describe Study, type: :model do
     is_expected.to define_enum_for(:study_stage).with(enum_options)
   end
 
+  context "when erb_status_needed? is true" do
+    let(:study) do
+      FactoryGirl.build(:study, protocol_needed: true,
+                                study_stage: :protocol_erb)
+    end
+
+    it "validates the presence of erb_status" do
+      study.erb_status = nil
+      expect(study).to be_invalid
+    end
+  end
+
+  context "when erb_status_needed? is false" do
+    let(:erb_status) { FactoryGirl.create(:submitted) }
+    let(:study) do
+      FactoryGirl.build(:study, protocol_needed: false,
+                                study_stage: :protocol_erb)
+    end
+
+    it "doesn't validate the presence of erb_status" do
+      study.erb_status = erb_status
+      expect(study).to be_valid
+    end
+  end
+
   context "when the when study_type field is 'Other'" do
     let(:study) { FactoryGirl.build(:study) }
     let(:other_study_type) { StudyType.find_by_name("Other") }
@@ -225,9 +250,12 @@ RSpec.describe Study, type: :model do
 
       it "logs changes to the study stage" do
         old_stage = study.study_stage
+        # erb_status is required in this stage too
+        study.erb_status = accept_status
+        study.save!
         study.study_stage = :protocol_erb
         study.save!
-        expect(study.reload.activities.length).to eq 2
+        expect(study.reload.activities.length).to eq 3 # create, stage and erb
         expect(study).to have_latest_activity(key: "study.study_stage_changed",
                                               parameters: {
                                                 attribute: "study_stage",
@@ -340,6 +368,7 @@ RSpec.describe Study, type: :model do
   end
 
   describe "#latest_stage_change" do
+    let(:accept_status) { FactoryGirl.create(:accept) }
     let(:study) { FactoryGirl.create(:study) }
 
     before do
@@ -356,6 +385,7 @@ RSpec.describe Study, type: :model do
 
     it "returns the latest stage change" do
       study.study_stage = "protocol_erb"
+      study.erb_status = accept_status
       study.save!
       study.study_stage = "delivery"
       study.save!
@@ -371,6 +401,7 @@ RSpec.describe Study, type: :model do
   end
 
   describe "#study_stage_since" do
+    let(:accept_status) { FactoryGirl.create(:accept) }
     let(:study) { FactoryGirl.create(:study) }
 
     before do
@@ -387,6 +418,7 @@ RSpec.describe Study, type: :model do
 
     it "returns the time of the latest study change" do
       study.study_stage = "protocol_erb"
+      study.erb_status = accept_status
       study.save!
       study.study_stage = "delivery"
       study.save!
@@ -454,6 +486,51 @@ RSpec.describe Study, type: :model do
 
       it "returns the current title" do
         expect(study.original_title).to eq original_title
+      end
+    end
+  end
+
+  describe "#erb_status_needed?" do
+    context "when protocol_needed is true" do
+      let(:study) { FactoryGirl.build(:study, protocol_needed: true) }
+
+      context "and study_stage is concept" do
+        it "returns false" do
+          study.study_stage = :concept
+          expect(study.erb_status_needed?).to be false
+        end
+      end
+
+      context "and study_stage is withdrawn_postponed" do
+        it "returns false" do
+          study.study_stage = :withdrawn_postponed
+          expect(study.erb_status_needed?).to be false
+        end
+      end
+
+      context "and study_stage is anything else" do
+        it "returns true" do
+          stages = Study.study_stages.keys
+          stages = stages.delete_if do |stage|
+            stage == "concept" || stage == "withdrawn_postponed"
+          end
+          puts stages
+          stages.each do |stage|
+            study.study_stage = stage
+            expect(study.erb_status_needed?).to be true
+          end
+        end
+      end
+    end
+
+    context "when protocol_needed is false" do
+      let(:study) { FactoryGirl.build(:study, protocol_needed: false) }
+
+      it "returns false for every stage" do
+        Study.study_stages.keys.each do |stage|
+          study.study_stage = stage
+          expect(study.erb_status_needed?).to be false
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,8 @@ RSpec.configure do |config|
     FactoryGirl.create(:other_internal) unless other_internal
     other_external = DisseminationCategory.find_by_name("Other external")
     FactoryGirl.create(:other_external) unless other_external
+    in_draft = ErbStatus.find_by_name("In draft")
+    FactoryGirl.create(:in_draft) unless in_draft
   end
 
   config.before(:each, type: :feature) do


### PR DESCRIPTION
- Adds some validation to check erb_status is set in the cases it needs to be
- Adds a new ERB Status In Draft to act as a kind of default

Note: I haven't made In draft an actual default because it's complicated
having it live in another table, and in any case I thought it would be better
to force the admin to choose a status when updating a study (the main time it
will need to be set) because it's equally likely it'll be something else (e.g.
already submitted).

Closes #70