### PR TITLE
Add template for displaying ERB Status changes.

### DIFF
--- a/app/admin/erb_status.rb
+++ b/app/admin/erb_status.rb
@@ -1,4 +1,15 @@
 ActiveAdmin.register ErbStatus do
-  permit_params :name
+  permit_params :name, :description, :good_bad_or_neutral
   menu parent: "Field options"
+
+  form do |f|
+    f.inputs "Edit Erb Status" do
+      f.input :name, as: :string
+      f.input :description, as: :string
+      f.input :good_bad_or_neutral,
+              as: :select,
+              collection: ErbStatus.good_bad_or_neutrals
+    end
+    f.actions
+  end
 end

--- a/app/models/erb_status.rb
+++ b/app/models/erb_status.rb
@@ -2,10 +2,12 @@
 #
 # Table name: erb_statuses
 #
-#  id         :integer          not null, primary key
-#  name       :text             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                  :integer          not null, primary key
+#  name                :text             not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  description         :text             not null
+#  good_bad_or_neutral :enum             default("neutral"), not null
 #
 # Indexes
 #
@@ -13,7 +15,15 @@
 #
 
 class ErbStatus < ActiveRecord::Base
+  enum good_bad_or_neutral: {
+    good: "good",
+    bad: "bad",
+    neutral: "neutral"
+  }
+
   has_many :studies, inverse_of: :erb_status
 
   validates :name, presence: true, uniqueness: true
+  validates :description, presence: true
+  validates :good_bad_or_neutral, presence: true
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -179,9 +179,14 @@ class Study < ActiveRecord::Base
           # It might be changing to nil though, hence find_by_id not find
           recipient = User.find_by_id(after)
         end
+        related_content = nil
+        if attr_name == "erb_status_id"
+          related_content = ErbStatus.find_by_id(after)
+        end
         create_activity key, parameters: params,
                              owner: owner,
-                             recipient: recipient
+                             recipient: recipient,
+                             related_content: related_content
       end
     end
   end

--- a/app/views/public_activity/study/_erb_status_id_changed.html.erb
+++ b/app/views/public_activity/study/_erb_status_id_changed.html.erb
@@ -1,0 +1,19 @@
+<% content_for :extra_classes, flush: true do %>
+    <% if a.related_content.bad? %>
+        timeline__item--negative
+    <% elsif a.related_content.good? %>
+        timeline__item--affirmative
+    <% else %>
+
+    <% end %>
+<% end %>
+<% content_for :title, flush: true do %>
+    <%= a.related_content.description %>
+<% end %>
+<% content_for :description, flush: true do %>
+  <% if a.owner.present? %>
+    Updated by <%= a.owner.name %>
+  <% else %>
+
+  <% end %>
+<% end %>

--- a/db/migrate/20160210104516_add_description_and_good_bad_neutral_to_erb_status.rb
+++ b/db/migrate/20160210104516_add_description_and_good_bad_neutral_to_erb_status.rb
@@ -1,0 +1,22 @@
+class AddDescriptionAndGoodBadNeutralToErbStatus < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE TYPE good_bad_neutral
+      AS ENUM ('good', 'bad', 'neutral');
+    SQL
+
+    add_column :erb_statuses, :description, :text, null: false
+    add_column(
+      :erb_statuses,
+      :good_bad_or_neutral,
+      :good_bad_neutral,
+      null: false,
+      default: "neutral")
+  end
+
+  def down
+    remove_column :erb_statuses, :description
+    remove_column :erb_statuses, :good_bad_or_neutral
+    execute "DROP TYPE good_bad_neutral;"
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,12 +101,24 @@ StudySetting.create(
 # Ethical Review Board (ERB) Statuses
 ErbStatus.create(
   [
-    { name: "Exempt" },
-    { name: "In draft" },
-    { name: "Submitted" },
-    { name: "Reject" },
-    { name: "Re-review" },
-    { name: "Accept" },
+    { name: "Exempt",
+      description: "Was marked as exempt from ERB",
+      good_bad_or_neutral: "good" },
+    { name: "In draft",
+      description: "Protocol is in draft",
+      good_bad_or_neutral: "neutral" },
+    { name: "Submitted",
+      description: "Protocol submitted to ERB",
+      good_bad_or_neutral: "neutral" },
+    { name: "Reject",
+      description: "Protocol was rejected by ERB",
+      good_bad_or_neutral: "bad" },
+    { name: "Re-review",
+      description: "Protocol re-submitted to ERB",
+      good_bad_or_neutral: "neutral" },
+    { name: "Accept",
+      description: "Protocol accepted by ERB",
+      good_bad_or_neutral: "good" },
   ]
 )
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -35,6 +35,17 @@ CREATE TYPE dissemination_category_type AS ENUM (
 
 
 --
+-- Name: good_bad_neutral; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE good_bad_neutral AS ENUM (
+    'good',
+    'bad',
+    'neutral'
+);
+
+
+--
 -- Name: study_stage; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -304,7 +315,9 @@ CREATE TABLE erb_statuses (
     id integer NOT NULL,
     name text NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    description text NOT NULL,
+    good_bad_or_neutral good_bad_neutral DEFAULT 'neutral'::good_bad_neutral NOT NULL
 );
 
 
@@ -1464,4 +1477,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160203150222');
 INSERT INTO schema_migrations (version) VALUES ('20160203164358');
 
 INSERT INTO schema_migrations (version) VALUES ('20160203182723');
+
+INSERT INTO schema_migrations (version) VALUES ('20160210104516');
 

--- a/spec/factories/erb_status.rb
+++ b/spec/factories/erb_status.rb
@@ -1,25 +1,37 @@
 FactoryGirl.define do
   factory :erb_status, aliases: [:exempt_status] do
     name "Exempt"
+    description "Was marked as exempt from ERB"
+    good_bad_or_neutral "good"
 
     factory :in_draft do
       name "In draft"
+      description "Protocol is in draft"
+      good_bad_or_neutral "neutral"
     end
 
     factory :submitted do
       name "Submitted"
+      description "Protocol submitted to ERB"
+      good_bad_or_neutral "neutral"
     end
 
     factory :reject do
       name "Reject"
+      description "Protocol was rejected by ERB"
+      good_bad_or_neutral "bad"
     end
 
     factory :rereview do
       name "Re-review"
+      description "Protocol re-submitted to ERB"
+      good_bad_or_neutral "neutral"
     end
 
     factory :accept do
       name "Accept"
+      description "Protocol accepted by ERB"
+      good_bad_or_neutral "good"
     end
   end
 end

--- a/spec/features/admin/erb_status_admin_spec.rb
+++ b/spec/features/admin/erb_status_admin_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "ERBStatusAdmin" do
   let(:resource_class) { ErbStatus }
 
   def fill_in_extra_required_fields
+    fill_in "Description", with: "Test erb status"
+    select "good", from: "Good bad or neutral"
   end
 
   it_behaves_like "simple model admin"

--- a/spec/models/erb_status_spec.rb
+++ b/spec/models/erb_status_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe ErbStatus, type: :model do
       with_options(null: false)
   end
 
+  it do
+    is_expected.to have_db_column(:description).of_type(:text).
+      with_options(null: false)
+  end
+
+  it do
+    is_expected.to have_db_column(:good_bad_or_neutral).of_type(:enum).
+      with_options(null: false, default: "neutral")
+  end
+
   # Indexes
   it { is_expected.to have_db_index(:name).unique(true) }
 
@@ -16,4 +26,6 @@ RSpec.describe ErbStatus, type: :model do
   # Validation
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
+  it { is_expected.to validate_presence_of(:description) }
+  it { is_expected.to validate_presence_of(:good_bad_or_neutral) }
 end

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -283,7 +283,8 @@ RSpec.describe Study, type: :model do
             attribute: "erb_status_id",
             before: nil,
             after: accept_status.id
-          })
+          },
+          related_content: accept_status)
       end
 
       it "logs changes to the principal investigator" do

--- a/spec/views/public_activity/study/_erb_status_id_changed.html.erb_spec.rb
+++ b/spec/views/public_activity/study/_erb_status_id_changed.html.erb_spec.rb
@@ -1,0 +1,94 @@
+# encoding: utf-8
+require "rails_helper"
+
+RSpec.describe "public_activity/study/_erb_status_id_changed.html.erb",
+               type: :view do
+  let(:partial) { "public_activity/study/erb_status_id_changed" }
+  let(:study) { FactoryGirl.create(:study) }
+  let(:user) { FactoryGirl.create(:user) }
+  let(:in_draft) do
+    ErbStatus.find_by_name("In draft") || FactoryGirl.create(:in_draft)
+  end
+  let(:submitted) { FactoryGirl.create(:submitted) }
+  let(:activity_without_owner) do
+    study.create_activity :erb_status_id_changed,
+                          parameters: { before: in_draft.id,
+                                        after: submitted.id },
+                          owner: nil,
+                          related_content: submitted
+  end
+  let(:activity_with_owner) do
+    study.create_activity :erb_status_id_changed,
+                          parameters: { before: in_draft.id,
+                                        after: submitted.id },
+                          owner: user,
+                          related_content: submitted
+  end
+
+  before do
+    PublicActivity.enabled = true
+    render partial: partial,
+           locals: { a: activity_with_owner, p: activity_with_owner.parameters }
+  end
+
+  after do
+    PublicActivity.enabled = false
+  end
+
+  context "when the erb status is neutral" do
+    it "is given neutral styling" do
+      expect(view.content_for(:extra_classes)).to be nil
+    end
+  end
+
+  context "when the erb status is good" do
+    let(:accept) { FactoryGirl.create(:accept) }
+    let(:positive_activity) do
+      study.create_activity :erb_status_id_changed,
+                            parameters: { before: in_draft.id,
+                                          after: accept.id },
+                            owner: nil,
+                            related_content: accept
+    end
+
+    before do
+      render partial: partial,
+             locals: { a: positive_activity, p: positive_activity.parameters }
+    end
+
+    it "is given positive styling" do
+      expected_class = "timeline__item--affirmative"
+      expect(view.content_for(:extra_classes)).to have_text expected_class
+    end
+  end
+
+  context "when the erb status is bad" do
+    let(:reject) { FactoryGirl.create(:reject) }
+    let(:negative_activity) do
+      study.create_activity :erb_status_id_changed,
+                            parameters: { before: in_draft.id,
+                                          after: reject.id },
+                            owner: nil,
+                            related_content: reject
+    end
+
+    before do
+      render partial: partial,
+             locals: { a: negative_activity, p: negative_activity.parameters }
+    end
+
+    it "is given negative styling" do
+      expected_class = "timeline__item--negative"
+      expect(view.content_for(:extra_classes)).to have_text expected_class
+    end
+  end
+
+  it "Sets the title from the status" do
+    expect(view.content_for(:title)).to have_text submitted.description
+  end
+
+  it "Sets the description to say who updated it" do
+    expected_text = "Updated by #{user.name}"
+    expect(view.content_for(:description)).to have_text expected_text
+  end
+end


### PR DESCRIPTION
This adds the missing template so that we can display changes to the ERB
status in a study's timeline. This was a bit more complicated than it seemed
because we want to have some nice textual descriptions of the status changes
but they're managed in the admin so we can't hardcode them. I've added some
new fields to the ErbStatus model to store a description and whether to show
a red, green or grey icon for that particular stage.

Closes #103
For #18