### PR TITLE
Remove dataset document type and output study stage

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -50,7 +50,6 @@ class Study < ActiveRecord::Base
     concept: "Concept",
     protocol_erb: "Protocol & ERB",
     delivery: "Delivery",
-    output: "Output",
     completion: "Completion",
     withdrawn_postponed: "Withdrawn or Postponed",
   }.freeze
@@ -63,7 +62,6 @@ class Study < ActiveRecord::Base
     concept: "concept",
     protocol_erb: "protocol_erb",
     delivery: "delivery",
-    output: "output",
     completion: "completion",
     withdrawn_postponed: "withdrawn_postponed",
   }
@@ -97,7 +95,6 @@ class Study < ActiveRecord::Base
 
   def self.active
     query = "study_stage = 'delivery' " \
-            "OR study_stage = 'output' " \
             "OR (study_stage = 'completion' and completed >= ?)"
     where(query, Time.zone.today - 1.year)
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -128,7 +128,6 @@ DocumentType.create(
     { name: "Protocol" },
     { name: "ERB documentation" },
     { name: "Data sharing agreements" },
-    { name: "Dataset" },
     { name: "Study report" },
     { name: "Interim results" },
     { name: "Other" },

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -53,7 +53,6 @@ CREATE TYPE study_stage AS ENUM (
     'concept',
     'protocol_erb',
     'delivery',
-    'output',
     'completion',
     'withdrawn_postponed'
 );
@@ -64,7 +63,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: active_admin_comments; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: active_admin_comments; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE active_admin_comments (
@@ -100,7 +99,7 @@ ALTER SEQUENCE active_admin_comments_id_seq OWNED BY active_admin_comments.id;
 
 
 --
--- Name: activities; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: activities; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE activities (
@@ -140,7 +139,7 @@ ALTER SEQUENCE activities_id_seq OWNED BY activities.id;
 
 
 --
--- Name: dissemination_categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: dissemination_categories; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE dissemination_categories (
@@ -173,7 +172,7 @@ ALTER SEQUENCE dissemination_categories_id_seq OWNED BY dissemination_categories
 
 
 --
--- Name: disseminations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: disseminations; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE disseminations (
@@ -208,7 +207,7 @@ ALTER SEQUENCE disseminations_id_seq OWNED BY disseminations.id;
 
 
 --
--- Name: document_types; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: document_types; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE document_types (
@@ -240,7 +239,7 @@ ALTER SEQUENCE document_types_id_seq OWNED BY document_types.id;
 
 
 --
--- Name: documents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: documents; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE documents (
@@ -276,7 +275,7 @@ ALTER SEQUENCE documents_id_seq OWNED BY documents.id;
 
 
 --
--- Name: enabler_barriers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: enabler_barriers; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE enabler_barriers (
@@ -308,7 +307,7 @@ ALTER SEQUENCE enabler_barriers_id_seq OWNED BY enabler_barriers.id;
 
 
 --
--- Name: erb_statuses; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: erb_statuses; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE erb_statuses (
@@ -341,7 +340,7 @@ ALTER SEQUENCE erb_statuses_id_seq OWNED BY erb_statuses.id;
 
 
 --
--- Name: impact_types; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: impact_types; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE impact_types (
@@ -373,7 +372,7 @@ ALTER SEQUENCE impact_types_id_seq OWNED BY impact_types.id;
 
 
 --
--- Name: msf_locations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: msf_locations; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE msf_locations (
@@ -405,7 +404,7 @@ ALTER SEQUENCE msf_locations_id_seq OWNED BY msf_locations.id;
 
 
 --
--- Name: publications; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: publications; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE publications (
@@ -441,7 +440,7 @@ ALTER SEQUENCE publications_id_seq OWNED BY publications.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE schema_migrations (
@@ -450,7 +449,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: studies; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: studies; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE studies (
@@ -502,7 +501,7 @@ ALTER SEQUENCE studies_id_seq OWNED BY studies.id;
 
 
 --
--- Name: studies_study_topics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: studies_study_topics; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE studies_study_topics (
@@ -512,7 +511,7 @@ CREATE TABLE studies_study_topics (
 
 
 --
--- Name: study_enabler_barriers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: study_enabler_barriers; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE study_enabler_barriers (
@@ -545,7 +544,7 @@ ALTER SEQUENCE study_enabler_barriers_id_seq OWNED BY study_enabler_barriers.id;
 
 
 --
--- Name: study_impacts; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: study_impacts; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE study_impacts (
@@ -578,7 +577,7 @@ ALTER SEQUENCE study_impacts_id_seq OWNED BY study_impacts.id;
 
 
 --
--- Name: study_notes; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: study_notes; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE study_notes (
@@ -610,7 +609,7 @@ ALTER SEQUENCE study_notes_id_seq OWNED BY study_notes.id;
 
 
 --
--- Name: study_settings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: study_settings; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE study_settings (
@@ -642,7 +641,7 @@ ALTER SEQUENCE study_settings_id_seq OWNED BY study_settings.id;
 
 
 --
--- Name: study_topics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: study_topics; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE study_topics (
@@ -674,7 +673,7 @@ ALTER SEQUENCE study_topics_id_seq OWNED BY study_topics.id;
 
 
 --
--- Name: study_types; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: study_types; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE study_types (
@@ -706,7 +705,7 @@ ALTER SEQUENCE study_types_id_seq OWNED BY study_types.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE TABLE users (
@@ -887,7 +886,7 @@ ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regcl
 
 
 --
--- Name: active_admin_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: active_admin_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY active_admin_comments
@@ -895,7 +894,7 @@ ALTER TABLE ONLY active_admin_comments
 
 
 --
--- Name: activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY activities
@@ -903,7 +902,7 @@ ALTER TABLE ONLY activities
 
 
 --
--- Name: dissemination_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: dissemination_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY dissemination_categories
@@ -911,7 +910,7 @@ ALTER TABLE ONLY dissemination_categories
 
 
 --
--- Name: disseminations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: disseminations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY disseminations
@@ -919,7 +918,7 @@ ALTER TABLE ONLY disseminations
 
 
 --
--- Name: document_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: document_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY document_types
@@ -927,7 +926,7 @@ ALTER TABLE ONLY document_types
 
 
 --
--- Name: documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY documents
@@ -935,7 +934,7 @@ ALTER TABLE ONLY documents
 
 
 --
--- Name: enabler_barriers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: enabler_barriers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY enabler_barriers
@@ -943,7 +942,7 @@ ALTER TABLE ONLY enabler_barriers
 
 
 --
--- Name: erb_statuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: erb_statuses_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY erb_statuses
@@ -951,7 +950,7 @@ ALTER TABLE ONLY erb_statuses
 
 
 --
--- Name: impact_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: impact_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY impact_types
@@ -959,7 +958,7 @@ ALTER TABLE ONLY impact_types
 
 
 --
--- Name: msf_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: msf_locations_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY msf_locations
@@ -967,7 +966,7 @@ ALTER TABLE ONLY msf_locations
 
 
 --
--- Name: publications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: publications_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY publications
@@ -975,7 +974,7 @@ ALTER TABLE ONLY publications
 
 
 --
--- Name: studies_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: studies_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY studies
@@ -983,7 +982,7 @@ ALTER TABLE ONLY studies
 
 
 --
--- Name: study_enabler_barriers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: study_enabler_barriers_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY study_enabler_barriers
@@ -991,7 +990,7 @@ ALTER TABLE ONLY study_enabler_barriers
 
 
 --
--- Name: study_impacts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: study_impacts_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY study_impacts
@@ -999,7 +998,7 @@ ALTER TABLE ONLY study_impacts
 
 
 --
--- Name: study_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: study_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY study_notes
@@ -1007,7 +1006,7 @@ ALTER TABLE ONLY study_notes
 
 
 --
--- Name: study_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: study_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY study_settings
@@ -1015,7 +1014,7 @@ ALTER TABLE ONLY study_settings
 
 
 --
--- Name: study_topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: study_topics_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY study_topics
@@ -1023,7 +1022,7 @@ ALTER TABLE ONLY study_topics
 
 
 --
--- Name: study_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: study_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY study_types
@@ -1031,7 +1030,7 @@ ALTER TABLE ONLY study_types
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace:
 --
 
 ALTER TABLE ONLY users
@@ -1039,266 +1038,266 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: index_active_admin_comments_on_author_type_and_author_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_active_admin_comments_on_author_type_and_author_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_active_admin_comments_on_author_type_and_author_id ON active_admin_comments USING btree (author_type, author_id);
 
 
 --
--- Name: index_active_admin_comments_on_namespace; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_active_admin_comments_on_namespace; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_active_admin_comments_on_namespace ON active_admin_comments USING btree (namespace);
 
 
 --
--- Name: index_active_admin_comments_on_resource_type_and_resource_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_active_admin_comments_on_resource_type_and_resource_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_active_admin_comments_on_resource_type_and_resource_id ON active_admin_comments USING btree (resource_type, resource_id);
 
 
 --
--- Name: index_activities_on_owner_id_and_owner_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_activities_on_owner_id_and_owner_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_activities_on_owner_id_and_owner_type ON activities USING btree (owner_id, owner_type);
 
 
 --
--- Name: index_activities_on_recipient_id_and_recipient_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_activities_on_recipient_id_and_recipient_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_activities_on_recipient_id_and_recipient_type ON activities USING btree (recipient_id, recipient_type);
 
 
 --
--- Name: index_activities_on_related_content_type_and_related_content_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_activities_on_related_content_type_and_related_content_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_activities_on_related_content_type_and_related_content_id ON activities USING btree (related_content_type, related_content_id);
 
 
 --
--- Name: index_activities_on_trackable_id_and_trackable_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_activities_on_trackable_id_and_trackable_type; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_activities_on_trackable_id_and_trackable_type ON activities USING btree (trackable_id, trackable_type);
 
 
 --
--- Name: index_dissemination_categories_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_dissemination_categories_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_dissemination_categories_on_name ON dissemination_categories USING btree (name);
 
 
 --
--- Name: index_disseminations_on_dissemination_category_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_disseminations_on_dissemination_category_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_disseminations_on_dissemination_category_id ON disseminations USING btree (dissemination_category_id);
 
 
 --
--- Name: index_disseminations_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_disseminations_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_disseminations_on_study_id ON disseminations USING btree (study_id);
 
 
 --
--- Name: index_document_types_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_document_types_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_document_types_on_name ON document_types USING btree (name);
 
 
 --
--- Name: index_documents_on_document_type_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_documents_on_document_type_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_documents_on_document_type_id ON documents USING btree (document_type_id);
 
 
 --
--- Name: index_documents_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_documents_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_documents_on_study_id ON documents USING btree (study_id);
 
 
 --
--- Name: index_enabler_barriers_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_enabler_barriers_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_enabler_barriers_on_name ON enabler_barriers USING btree (name);
 
 
 --
--- Name: index_erb_statuses_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_erb_statuses_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_erb_statuses_on_name ON erb_statuses USING btree (name);
 
 
 --
--- Name: index_impact_types_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_impact_types_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_impact_types_on_name ON impact_types USING btree (name);
 
 
 --
--- Name: index_msf_locations_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_msf_locations_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_msf_locations_on_name ON msf_locations USING btree (name);
 
 
 --
--- Name: index_publications_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_publications_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_publications_on_study_id ON publications USING btree (study_id);
 
 
 --
--- Name: index_studies_on_erb_status_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_studies_on_erb_status_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_studies_on_erb_status_id ON studies USING btree (erb_status_id);
 
 
 --
--- Name: index_studies_on_principal_investigator_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_studies_on_principal_investigator_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_studies_on_principal_investigator_id ON studies USING btree (principal_investigator_id);
 
 
 --
--- Name: index_studies_on_research_manager_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_studies_on_research_manager_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_studies_on_research_manager_id ON studies USING btree (research_manager_id);
 
 
 --
--- Name: index_studies_on_study_setting_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_studies_on_study_setting_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_studies_on_study_setting_id ON studies USING btree (study_setting_id);
 
 
 --
--- Name: index_studies_on_study_type_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_studies_on_study_type_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_studies_on_study_type_id ON studies USING btree (study_type_id);
 
 
 --
--- Name: index_studies_study_topics_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_studies_study_topics_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_studies_study_topics_on_study_id ON studies_study_topics USING btree (study_id);
 
 
 --
--- Name: index_studies_study_topics_on_study_topic_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_studies_study_topics_on_study_topic_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_studies_study_topics_on_study_topic_id ON studies_study_topics USING btree (study_topic_id);
 
 
 --
--- Name: index_study_enabler_barriers_on_enabler_barrier_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_enabler_barriers_on_enabler_barrier_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_study_enabler_barriers_on_enabler_barrier_id ON study_enabler_barriers USING btree (enabler_barrier_id);
 
 
 --
--- Name: index_study_enabler_barriers_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_enabler_barriers_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_study_enabler_barriers_on_study_id ON study_enabler_barriers USING btree (study_id);
 
 
 --
--- Name: index_study_impacts_on_impact_type_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_impacts_on_impact_type_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_study_impacts_on_impact_type_id ON study_impacts USING btree (impact_type_id);
 
 
 --
--- Name: index_study_impacts_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_impacts_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_study_impacts_on_study_id ON study_impacts USING btree (study_id);
 
 
 --
--- Name: index_study_notes_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_notes_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_study_notes_on_study_id ON study_notes USING btree (study_id);
 
 
 --
--- Name: index_study_settings_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_settings_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_study_settings_on_name ON study_settings USING btree (name);
 
 
 --
--- Name: index_study_topics_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_topics_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_study_topics_on_name ON study_topics USING btree (name);
 
 
 --
--- Name: index_study_types_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_study_types_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_study_types_on_name ON study_types USING btree (name);
 
 
 --
--- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_confirmation_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_users_on_confirmation_token ON users USING btree (confirmation_token);
 
 
 --
--- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_users_on_email ON users USING btree (email);
 
 
 --
--- Name: index_users_on_msf_location_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_msf_location_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_users_on_msf_location_id ON users USING btree (msf_location_id);
 
 
 --
--- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX index_users_on_reset_password_token ON users USING btree (reset_password_token);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -4,7 +4,7 @@ require "support/study_contribution_controller_shared_examples"
 RSpec.describe DocumentsController, type: :controller do
   describe "POST #create" do
     let(:study) { FactoryGirl.create(:study) }
-    let(:document_type) { FactoryGirl.create(:dataset_doc_type) }
+    let(:document_type) { FactoryGirl.create(:erb_documentation_doc_type) }
     let(:document_upload) do
       fixture_file_upload("test.pdf", "application/pdf")
     end

--- a/spec/factories/document_type.rb
+++ b/spec/factories/document_type.rb
@@ -8,9 +8,6 @@ FactoryGirl.define do
     factory :data_sharing_doc_type do
       name "Data sharing agreements"
     end
-    factory :dataset_doc_type do
-      name "Dataset"
-    end
     factory :study_report_doc_type do
       name "Study report"
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ApplicationHelper, type: :helper do
         concept: { label: "Concept", state: "todo" },
         protocol_erb: { label: "Protocol & ERB", state: "todo" },
         delivery: { label: "Delivery", state: "todo" },
-        output: { label: "Output", state: "todo" },
         completion: { label: "Completion", state: "todo" },
       }
     end
@@ -49,7 +48,6 @@ RSpec.describe ApplicationHelper, type: :helper do
           expected_timeline[:concept][:state] = "done"
           expected_timeline[:protocol_erb][:state] = "done"
           expected_timeline[:delivery][:state] = "done"
-          expected_timeline[:output][:state] = "done"
           expected_timeline[:completion][:state] = "doing"
           expect(study_timeline(study)).to eq expected_timeline
         end
@@ -122,8 +120,6 @@ RSpec.describe ApplicationHelper, type: :helper do
           study.save!
           study.study_stage = "delivery"
           study.save!
-          study.study_stage = "output"
-          study.save!
           study.study_stage = "completion"
           study.save!
 
@@ -131,7 +127,6 @@ RSpec.describe ApplicationHelper, type: :helper do
           expected_timeline[:concept][:state] = "done"
           expected_timeline[:protocol_erb][:state] = "done"
           expected_timeline[:delivery][:state] = "done"
-          expected_timeline[:output][:state] = "done"
           expected_timeline[:completion][:state] = "doing"
           expect(study_timeline(study)).to eq expected_timeline
         end
@@ -141,9 +136,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         let(:study) { FactoryGirl.create(:study) }
 
         it "returns a timeline with multiple entries" do
-          study.study_stage = "protocol_erb"
           study.erb_status = accept_status
-          study.save!
           study.study_stage = "delivery"
           study.save!
           study.study_stage = "completion"
@@ -151,10 +144,9 @@ RSpec.describe ApplicationHelper, type: :helper do
 
           expected_timeline = base_timeline
           expected_timeline[:concept][:state] = "done"
+          # We expect the helper to fill this in for us anyway
           expected_timeline[:protocol_erb][:state] = "done"
           expected_timeline[:delivery][:state] = "done"
-          # We expect the helper to fill this in for us anyway
-          expected_timeline[:output][:state] = "done"
           expected_timeline[:completion][:state] = "doing"
           expect(study_timeline(study)).to eq expected_timeline
         end
@@ -176,36 +168,8 @@ RSpec.describe ApplicationHelper, type: :helper do
           expected_timeline[:concept][:state] = "done"
           expected_timeline[:protocol_erb][:state] = "done"
           expected_timeline[:delivery][:state] = "done"
-          # We expect the helper to delete these next two
-          expected_timeline.delete(:output)
+          # We expect the helper to delete this one
           expected_timeline.delete(:completion)
-          expected_timeline[:withdrawn_postponed] = {
-            label: "Withdrawn or Postponed",
-            state: "doing"
-          }
-          expect(study_timeline(study)).to eq expected_timeline
-        end
-      end
-
-      context "when a study has skipped a stage and then been withdrawn" do
-        let(:study) { FactoryGirl.create(:study) }
-
-        it "returns a timeline with multiple entries" do
-          study.study_stage = "delivery"
-          study.erb_status = accept_status
-          study.save!
-          study.study_stage = "withdrawn_postponed"
-          study.save!
-
-          expected_timeline = base_timeline
-          # The helper should complete these
-          expected_timeline[:concept][:state] = "done"
-          expected_timeline[:protocol_erb][:state] = "done"
-          expected_timeline[:delivery][:state] = "done"
-          # We expect the helper to delete these
-          expected_timeline.delete(:output)
-          expected_timeline.delete(:completion)
-          # This should be the final state
           expected_timeline[:withdrawn_postponed] = {
             label: "Withdrawn or Postponed",
             state: "doing"

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -83,7 +83,6 @@ RSpec.describe Study, type: :model do
       concept: "concept",
       protocol_erb: "protocol_erb",
       delivery: "delivery",
-      output: "output",
       completion: "completion",
       withdrawn_postponed: "withdrawn_postponed",
     }
@@ -550,8 +549,6 @@ RSpec.describe Study, type: :model do
     let(:active_studies) do
       [
         FactoryGirl.create(:study, study_stage: :delivery,
-                                   protocol_needed: false),
-        FactoryGirl.create(:study, study_stage: :output,
                                    protocol_needed: false),
         FactoryGirl.create(:study, study_stage: :completion,
                                    protocol_needed: false,


### PR DESCRIPTION
This removes these two options as requested by MSF.

Note: We'll need to do a complete reload of the db schema and data after this
is merged, because it alters the study_stage ENUM in postgres, and it's much
easier to do that with a `rake db:reset` than in a migration.

Closes #92
Closes #98