### PR TITLE
Track which user created the various contributed data types

### DIFF
--- a/app/admin/dissemination.rb
+++ b/app/admin/dissemination.rb
@@ -1,10 +1,11 @@
 ActiveAdmin.register Dissemination do
-  permit_params :dissemination_category_id, :study_id, :details,
+  permit_params :dissemination_category_id, :study_id, :details, :user_id,
                 :fed_back_to_field, :other_dissemination_category
 
   menu priority: 3
 
   filter :study
+  filter :user
   filter :created_at
   filter :dissemination_category
 end

--- a/app/admin/document.rb
+++ b/app/admin/document.rb
@@ -1,9 +1,10 @@
 ActiveAdmin.register Document do
-  permit_params :document_type_id, :study_id, :document
+  permit_params :document_type_id, :study_id, :document, :user_id
 
   menu priority: 3
 
   filter :study
+  filter :user
   filter :created_at
   filter :document_type
 
@@ -12,6 +13,7 @@ ActiveAdmin.register Document do
     f.inputs "Details" do
       f.input :document_type
       f.input :study
+      f.input :user
       f.input :document, as: :file
     end
     f.actions
@@ -19,9 +21,10 @@ ActiveAdmin.register Document do
 
   index do
     selectable_column
-    column :study
     column :document_type
     column :document_file_name
+    column :user
+    column :study
     column :created_at
     column :updated_at
     actions

--- a/app/admin/publication.rb
+++ b/app/admin/publication.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Publication do
   permit_params :doi_number, :study_id, :lead_author, :article_title,
-                :book_or_journal_title, :publication_year
+                :book_or_journal_title, :publication_year, :user_id
 
   menu priority: 3
 
@@ -11,6 +11,7 @@ ActiveAdmin.register Publication do
     f.semantic_errors
     f.inputs "Details" do
       f.input :study
+      f.input :user
       f.input :doi_number, as: :string
       f.input :lead_author, as: :string
       f.input :article_title, as: :string

--- a/app/admin/study_enabler_barrier.rb
+++ b/app/admin/study_enabler_barrier.rb
@@ -1,9 +1,10 @@
 ActiveAdmin.register StudyEnablerBarrier do
-  permit_params :enabler_barrier_id, :study_id, :description
+  permit_params :enabler_barrier_id, :study_id, :description, :user_id
 
   menu priority: 4
 
   filter :study
+  filter :user
   filter :enabler_barrier
   filter :created_at
 end

--- a/app/admin/study_impact.rb
+++ b/app/admin/study_impact.rb
@@ -1,9 +1,10 @@
 ActiveAdmin.register StudyImpact do
-  permit_params :impact_type_id, :study_id, :description
+  permit_params :impact_type_id, :study_id, :description, :user_id
 
   menu priority: 4
 
   filter :study
+  filter :user
   filter :impact_type_id
   filter :created_at
 end

--- a/app/admin/study_note.rb
+++ b/app/admin/study_note.rb
@@ -1,9 +1,10 @@
 ActiveAdmin.register StudyNote do
-  permit_params :notes, :study_id
+  permit_params :notes, :study_id, :user_id
 
   menu priority: 3
 
   filter :study
+  filter :user
   filter :notes
   filter :created_at
 end

--- a/app/controllers/concerns/creating_multiple_study_resources.rb
+++ b/app/controllers/concerns/creating_multiple_study_resources.rb
@@ -1,7 +1,7 @@
 module CreatingMultipleStudyResources
   extend ActiveSupport::Concern
 
-  def create_multiple_resources(study, resource_class, params, id_param,
+  def create_multiple_resources(study, user, resource_class, params, id_param,
                                 description_param)
     resources = {}
     resource_class.transaction do
@@ -13,6 +13,7 @@ module CreatingMultipleStudyResources
           id_param => id,
           description_param => descriptions[id])
         resource.study = study
+        resource.user = user
         resources[id.to_i] = resource
         # We call this and ignore the output for now, so that we can get
         # errors for each resource in one go and then decide whether to rollback

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -3,6 +3,7 @@ class DocumentsController < ApplicationController
     @study = Study.find(params[:study_id])
     @document = Document.new(document_params)
     @document.study = @study
+    @document.user = current_user
     if @document.save
       redirect_to @study, notice: "Document created successfully"
     else

--- a/app/controllers/outputs_controller.rb
+++ b/app/controllers/outputs_controller.rb
@@ -22,6 +22,7 @@ class OutputsController < ApplicationController
   def create_study_impact
     @study_impacts = create_multiple_resources(
       @study,
+      current_user,
       StudyImpact,
       study_impact_params,
       :impact_type_id,
@@ -55,6 +56,7 @@ class OutputsController < ApplicationController
   def create_dissemination
     @dissemination = Dissemination.new(dissemination_params)
     @dissemination.study = @study
+    @dissemination.user = current_user
     if @dissemination.save
       redirect_to @study, notice: "Dissemination created successfully"
     else
@@ -73,6 +75,7 @@ class OutputsController < ApplicationController
   def create_publication
     @publication = Publication.new(publication_params)
     @publication.study = @study
+    @publication.user = current_user
     if @publication.save
       redirect_to @study, notice: "Publication created successfully"
     else

--- a/app/controllers/study_enabler_barriers_controller.rb
+++ b/app/controllers/study_enabler_barriers_controller.rb
@@ -8,6 +8,7 @@ class StudyEnablerBarriersController < ApplicationController
     # way of knowing whether someone actually wanted to select
     @study_enabler_barriers = create_multiple_resources(
       @study,
+      current_user,
       StudyEnablerBarrier,
       study_enabler_barrier_params,
       :enabler_barrier_id,

--- a/app/controllers/study_notes_controller.rb
+++ b/app/controllers/study_notes_controller.rb
@@ -3,6 +3,7 @@ class StudyNotesController < ApplicationController
     @study = Study.find(params[:study_id])
     @study_note = StudyNote.new(study_note_params)
     @study_note.study = @study
+    @study_note.user = current_user
     if @study_note.save
       redirect_to @study, notice: "Note created successfully"
     else

--- a/app/models/dissemination.rb
+++ b/app/models/dissemination.rb
@@ -11,19 +11,21 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  other_dissemination_category :text
+#  user_id                      :integer
 #
 # Indexes
 #
 #  index_disseminations_on_dissemination_category_id  (dissemination_category_id)
 #  index_disseminations_on_study_id                   (study_id)
+#  index_disseminations_on_user_id                    (user_id)
 #
-# rubocop:enable Metrics/LineLength
 
 class Dissemination < ActiveRecord::Base
   include StudyActivityTrackable
 
   belongs_to :dissemination_category, inverse_of: :disseminations
   belongs_to :study, inverse_of: :disseminations
+  belongs_to :user, inverse_of: :disseminations
 
   validates :study, presence: true
   validates :dissemination_category, presence: true

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -11,11 +11,13 @@
 #  document_content_type :string
 #  document_file_size    :integer
 #  document_updated_at   :datetime
+#  user_id               :integer
 #
 # Indexes
 #
 #  index_documents_on_document_type_id  (document_type_id)
 #  index_documents_on_study_id          (study_id)
+#  index_documents_on_user_id           (user_id)
 #
 
 class Document < ActiveRecord::Base
@@ -74,6 +76,7 @@ class Document < ActiveRecord::Base
 
   belongs_to :document_type, inverse_of: :documents
   belongs_to :study, inverse_of: :documents
+  belongs_to :user, inverse_of: :documents
   validates :document_type, presence: true
   validates :study, presence: true
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -11,16 +11,19 @@
 #  publication_year      :integer          not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#  user_id               :integer
 #
 # Indexes
 #
 #  index_publications_on_study_id  (study_id)
+#  index_publications_on_user_id   (user_id)
 #
 
 class Publication < ActiveRecord::Base
   include StudyActivityTrackable
 
   belongs_to :study, inverse_of: :publications
+  belongs_to :user, inverse_of: :publications
 
   validates :lead_author, presence: true
   validates :article_title, presence: true

--- a/app/models/study_enabler_barrier.rb
+++ b/app/models/study_enabler_barrier.rb
@@ -8,11 +8,13 @@
 #  description        :text             not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  user_id            :integer
 #
 # Indexes
 #
 #  index_study_enabler_barriers_on_enabler_barrier_id  (enabler_barrier_id)
 #  index_study_enabler_barriers_on_study_id            (study_id)
+#  index_study_enabler_barriers_on_user_id             (user_id)
 #
 
 class StudyEnablerBarrier < ActiveRecord::Base
@@ -20,6 +22,7 @@ class StudyEnablerBarrier < ActiveRecord::Base
 
   belongs_to :study, inverse_of: :study_enabler_barriers
   belongs_to :enabler_barrier, inverse_of: :study_enabler_barriers
+  belongs_to :user, inverse_of: :study_enabler_barriers
 
   validates :study, presence: true
   validates :enabler_barrier, presence: true

--- a/app/models/study_impact.rb
+++ b/app/models/study_impact.rb
@@ -8,11 +8,13 @@
 #  description    :text             not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  user_id        :integer
 #
 # Indexes
 #
 #  index_study_impacts_on_impact_type_id  (impact_type_id)
 #  index_study_impacts_on_study_id        (study_id)
+#  index_study_impacts_on_user_id         (user_id)
 #
 
 class StudyImpact < ActiveRecord::Base
@@ -20,6 +22,8 @@ class StudyImpact < ActiveRecord::Base
 
   belongs_to :study, inverse_of: :study_impacts
   belongs_to :impact_type, inverse_of: :study_impacts
+  belongs_to :user, inverse_of: :study_impacts
+
   validates :study, presence: true
   validates :impact_type, presence: true
   validates :description, presence: true

--- a/app/models/study_note.rb
+++ b/app/models/study_note.rb
@@ -7,16 +7,19 @@
 #  study_id   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer
 #
 # Indexes
 #
 #  index_study_notes_on_study_id  (study_id)
+#  index_study_notes_on_user_id   (user_id)
 #
 
 class StudyNote < ActiveRecord::Base
   include StudyActivityTrackable
 
   belongs_to :study, inverse_of: :study_notes
+  belongs_to :user, inverse_of: :study_notes
 
   validates :study, presence: true
   validates :notes, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,13 @@ class User < ActiveRecord::Base
                                  class_name: "PublicActivity::Activity",
                                  dependent: :destroy
 
+  has_many :documents, inverse_of: :user
+  has_many :publications, inverse_of: :user
+  has_many :disseminations, inverse_of: :user
+  has_many :study_impacts, inverse_of: :user
+  has_many :study_notes, inverse_of: :user
+  has_many :study_enabler_barriers, inverse_of: :user
+
   validates :name, presence: true
   validate :external_location_is_set_if_msf_location_is_external
 

--- a/db/migrate/20160210161706_add_user_to_contribution_models.rb
+++ b/db/migrate/20160210161706_add_user_to_contribution_models.rb
@@ -1,0 +1,10 @@
+class AddUserToContributionModels < ActiveRecord::Migration
+  def change
+    add_reference :documents, :user, index: true, foreign_key: true
+    add_reference :publications, :user, index: true, foreign_key: true
+    add_reference :disseminations, :user, index: true, foreign_key: true
+    add_reference :study_impacts, :user, index: true, foreign_key: true
+    add_reference :study_notes, :user, index: true, foreign_key: true
+    add_reference :study_enabler_barriers, :user, index: true, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -183,7 +183,8 @@ CREATE TABLE disseminations (
     fed_back_to_field boolean NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    other_dissemination_category text
+    other_dissemination_category text,
+    user_id integer
 );
 
 
@@ -251,7 +252,8 @@ CREATE TABLE documents (
     document_file_name character varying,
     document_content_type character varying,
     document_file_size integer,
-    document_updated_at timestamp without time zone
+    document_updated_at timestamp without time zone,
+    user_id integer
 );
 
 
@@ -416,7 +418,8 @@ CREATE TABLE publications (
     book_or_journal_title text NOT NULL,
     publication_year integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    user_id integer
 );
 
 
@@ -520,7 +523,8 @@ CREATE TABLE study_enabler_barriers (
     enabler_barrier_id integer NOT NULL,
     description text NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    user_id integer
 );
 
 
@@ -553,7 +557,8 @@ CREATE TABLE study_impacts (
     impact_type_id integer NOT NULL,
     description text NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    user_id integer
 );
 
 
@@ -585,7 +590,8 @@ CREATE TABLE study_notes (
     notes text NOT NULL,
     study_id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    user_id integer
 );
 
 
@@ -1108,6 +1114,13 @@ CREATE INDEX index_disseminations_on_study_id ON disseminations USING btree (stu
 
 
 --
+-- Name: index_disseminations_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE INDEX index_disseminations_on_user_id ON disseminations USING btree (user_id);
+
+
+--
 -- Name: index_document_types_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
@@ -1126,6 +1139,13 @@ CREATE INDEX index_documents_on_document_type_id ON documents USING btree (docum
 --
 
 CREATE INDEX index_documents_on_study_id ON documents USING btree (study_id);
+
+
+--
+-- Name: index_documents_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE INDEX index_documents_on_user_id ON documents USING btree (user_id);
 
 
 --
@@ -1161,6 +1181,13 @@ CREATE UNIQUE INDEX index_msf_locations_on_name ON msf_locations USING btree (na
 --
 
 CREATE INDEX index_publications_on_study_id ON publications USING btree (study_id);
+
+
+--
+-- Name: index_publications_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE INDEX index_publications_on_user_id ON publications USING btree (user_id);
 
 
 --
@@ -1227,6 +1254,13 @@ CREATE INDEX index_study_enabler_barriers_on_study_id ON study_enabler_barriers 
 
 
 --
+-- Name: index_study_enabler_barriers_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE INDEX index_study_enabler_barriers_on_user_id ON study_enabler_barriers USING btree (user_id);
+
+
+--
 -- Name: index_study_impacts_on_impact_type_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
@@ -1241,10 +1275,24 @@ CREATE INDEX index_study_impacts_on_study_id ON study_impacts USING btree (study
 
 
 --
+-- Name: index_study_impacts_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE INDEX index_study_impacts_on_user_id ON study_impacts USING btree (user_id);
+
+
+--
 -- Name: index_study_notes_on_study_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
 --
 
 CREATE INDEX index_study_notes_on_study_id ON study_notes USING btree (study_id);
+
+
+--
+-- Name: index_study_notes_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace:
+--
+
+CREATE INDEX index_study_notes_on_user_id ON study_notes USING btree (user_id);
 
 
 --
@@ -1304,6 +1352,14 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v
 
 
 --
+-- Name: fk_rails_03839ae5f9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY study_notes
+    ADD CONSTRAINT fk_rails_03839ae5f9 FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+--
 -- Name: fk_rails_03e5ee9cba; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1312,11 +1368,27 @@ ALTER TABLE ONLY users
 
 
 --
+-- Name: fk_rails_086c771341; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY disseminations
+    ADD CONSTRAINT fk_rails_086c771341 FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+--
 -- Name: fk_rails_0e2a1a9789; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY documents
     ADD CONSTRAINT fk_rails_0e2a1a9789 FOREIGN KEY (study_id) REFERENCES studies(id);
+
+
+--
+-- Name: fk_rails_2be0318c46; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY documents
+    ADD CONSTRAINT fk_rails_2be0318c46 FOREIGN KEY (user_id) REFERENCES users(id);
 
 
 --
@@ -1336,6 +1408,14 @@ ALTER TABLE ONLY study_notes
 
 
 --
+-- Name: fk_rails_4c9eefc8e4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY study_enabler_barriers
+    ADD CONSTRAINT fk_rails_4c9eefc8e4 FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+--
 -- Name: fk_rails_529dd6c0d7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1344,11 +1424,27 @@ ALTER TABLE ONLY studies
 
 
 --
+-- Name: fk_rails_5b8fd83dce; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY publications
+    ADD CONSTRAINT fk_rails_5b8fd83dce FOREIGN KEY (user_id) REFERENCES users(id);
+
+
+--
 -- Name: fk_rails_656a38bbd9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY study_impacts
     ADD CONSTRAINT fk_rails_656a38bbd9 FOREIGN KEY (impact_type_id) REFERENCES impact_types(id);
+
+
+--
+-- Name: fk_rails_72e4b2d4a3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY study_impacts
+    ADD CONSTRAINT fk_rails_72e4b2d4a3 FOREIGN KEY (user_id) REFERENCES users(id);
 
 
 --
@@ -1479,3 +1575,4 @@ INSERT INTO schema_migrations (version) VALUES ('20160203182723');
 
 INSERT INTO schema_migrations (version) VALUES ('20160210104516');
 
+INSERT INTO schema_migrations (version) VALUES ('20160210161706');

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe DocumentsController, type: :controller do
   describe "POST #create" do
     let(:study) { FactoryGirl.create(:study) }
     let(:document_type) { FactoryGirl.create(:erb_documentation_doc_type) }
+    let(:user) { FactoryGirl.create(:user) }
     let(:document_upload) do
       fixture_file_upload("test.pdf", "application/pdf")
     end

--- a/spec/controllers/outputs_controller_spec.rb
+++ b/spec/controllers/outputs_controller_spec.rb
@@ -5,6 +5,7 @@ require "support/study_multiple_resources_controller_shared_examples"
 RSpec.describe OutputsController, type: :controller do
   describe "POST #create" do
     let(:study) { FactoryGirl.create(:study) }
+    let(:user) { FactoryGirl.create(:user) }
 
     context "when no output type is selected" do
       let(:attributes) do

--- a/spec/controllers/study_enabler_barriers_controller_spec.rb
+++ b/spec/controllers/study_enabler_barriers_controller_spec.rb
@@ -4,6 +4,7 @@ require "support/study_multiple_resources_controller_shared_examples"
 RSpec.describe StudyEnablerBarriersController, type: :controller do
   describe "POST #create_multiple", :truncation do
     let(:study) { FactoryGirl.create(:study) }
+    let(:user) { FactoryGirl.create(:user) }
 
     context "when one enabler/barrier is submitted" do
       let(:patient_barrier) { FactoryGirl.create(:patient_barrier) }

--- a/spec/controllers/study_notes_controller.rb
+++ b/spec/controllers/study_notes_controller.rb
@@ -4,6 +4,7 @@ require "support/study_contribution_controller_shared_examples"
 RSpec.describe StudyNotesController, type: :controller do
   describe "POST #create" do
     let(:study) { FactoryGirl.create(:study) }
+    let(:user) { FactoryGirl.create(:user) }
     let(:valid_attributes) do
       {
         study_id: study.id,

--- a/spec/features/admin/dissemination_admin_spec.rb
+++ b/spec/features/admin/dissemination_admin_spec.rb
@@ -3,6 +3,7 @@ require "support/user_account_feature_helper"
 
 RSpec.describe "DisseminationAdmin" do
   let(:admin_user) { FactoryGirl.create(:admin_user) }
+  let!(:user) { FactoryGirl.create(:user) }
   let!(:study) { FactoryGirl.create(:study) }
   let!(:category) { FactoryGirl.create(:working_group_category) }
 
@@ -17,11 +18,13 @@ RSpec.describe "DisseminationAdmin" do
     check "Fed back to field"
     select category.name, from: "Dissemination category"
     select study.title, from: "Study"
+    select user.name, from: "User"
     click_button "Create Dissemination"
     expect(page).to have_text "Dissemination was successfully created"
     dissemination = Dissemination.find_by_details("A test dissemination")
     expect(dissemination).not_to be nil
     expect(dissemination.study).to eq study
+    expect(dissemination.user).to eq user
     expect(dissemination.dissemination_category).to eq category
     expect(dissemination.fed_back_to_field).to be true
   end

--- a/spec/features/admin/document_admin_spec.rb
+++ b/spec/features/admin/document_admin_spec.rb
@@ -3,6 +3,7 @@ require "support/user_account_feature_helper"
 
 RSpec.describe "DocumentAdmin" do
   let(:admin_user) { FactoryGirl.create(:admin_user) }
+  let!(:user) { FactoryGirl.create(:user) }
   let!(:study) { FactoryGirl.create(:study) }
   let!(:document_type) { FactoryGirl.create(:protocol_doc_type) }
 
@@ -15,6 +16,7 @@ RSpec.describe "DocumentAdmin" do
     click_link "New Document"
     select document_type.name, from: "Document type"
     select study.title, from: "Study"
+    select user.name, from: "User"
     attach_file "Document", "spec/fixtures/test.pdf"
     click_button "Create Document"
     expect(page).to have_text "Document was successfully created"
@@ -24,6 +26,7 @@ RSpec.describe "DocumentAdmin" do
       document_type_id: document_type.id,
     ).first
     expect(document).not_to be nil
+    expect(document.user).to eq user
     expect(document.document).not_to be nil
   end
 

--- a/spec/features/admin/publication_admin_spec.rb
+++ b/spec/features/admin/publication_admin_spec.rb
@@ -3,6 +3,7 @@ require "support/user_account_feature_helper"
 
 RSpec.describe "PublicationAdmin" do
   let(:admin_user) { FactoryGirl.create(:admin_user) }
+  let!(:user) { FactoryGirl.create(:user) }
   let!(:study) { FactoryGirl.create(:study) }
 
   before do
@@ -17,11 +18,13 @@ RSpec.describe "PublicationAdmin" do
     fill_in "Book or journal title", with: "Test Journal"
     fill_in "Publication year", with: "2015"
     select study.title, from: "Study"
+    select user.name, from: "User"
     click_button "Create Publication"
     expect(page).to have_text "Publication was successfully created"
     publication = Publication.find_by_lead_author("Test Author")
     expect(publication).not_to be nil
     expect(publication.study).to eq study
+    expect(publication.user).to eq user
     expect(publication.article_title).to eq "Test Article"
     expect(publication.book_or_journal_title).to eq "Test Journal"
     expect(publication.publication_year).to eq 2015

--- a/spec/features/admin/study_enabler_barrier_admin_spec.rb
+++ b/spec/features/admin/study_enabler_barrier_admin_spec.rb
@@ -3,6 +3,7 @@ require "support/user_account_feature_helper"
 
 RSpec.describe "StudyEnablerBarrierAdmin" do
   let(:admin_user) { FactoryGirl.create(:admin_user) }
+  let!(:user) { FactoryGirl.create(:user) }
   let!(:study) { FactoryGirl.create(:study) }
   let!(:enabler_barrier) { FactoryGirl.create(:delivery_barrier) }
 
@@ -15,12 +16,14 @@ RSpec.describe "StudyEnablerBarrierAdmin" do
     click_link "New Study Enabler Barrier"
     select enabler_barrier.name, from: "Enabler barrier"
     select study.title, from: "Study"
+    select user.name, from: "User"
     fill_in "Description", with: "Test study enabler"
     click_button "Create Study enabler barrier"
     expect(page).to have_text "Study enabler barrier was successfully created"
     enabler = StudyEnablerBarrier.find_by_description("Test study enabler")
     expect(enabler).not_to be nil
     expect(enabler.study).to eq study
+    expect(enabler.user).to eq user
     expect(enabler.enabler_barrier).to eq enabler_barrier
   end
 

--- a/spec/features/admin/study_impact_admin_spec.rb
+++ b/spec/features/admin/study_impact_admin_spec.rb
@@ -3,6 +3,7 @@ require "support/user_account_feature_helper"
 
 RSpec.describe "StudyImpactAdmin" do
   let(:admin_user) { FactoryGirl.create(:admin_user) }
+  let!(:user) { FactoryGirl.create(:user) }
   let!(:study) { FactoryGirl.create(:study) }
   let!(:impact_type) { FactoryGirl.create(:programme_impact) }
 
@@ -15,12 +16,14 @@ RSpec.describe "StudyImpactAdmin" do
     click_link "New Study Impact"
     select impact_type.name, from: "Impact type"
     select study.title, from: "Study"
+    select user.name, from: "User"
     fill_in "Description", with: "Test study impact"
     click_button "Create Study impact"
     expect(page).to have_text "Study impact was successfully created"
     impact = StudyImpact.find_by_description("Test study impact")
     expect(impact).not_to be nil
     expect(impact.study).to eq study
+    expect(impact.user).to eq user
     expect(impact.impact_type).to eq impact_type
   end
 

--- a/spec/features/admin/study_note_admin_spec.rb
+++ b/spec/features/admin/study_note_admin_spec.rb
@@ -3,6 +3,7 @@ require "support/user_account_feature_helper"
 
 RSpec.describe "StudyNoteAdmin" do
   let(:admin_user) { FactoryGirl.create(:admin_user) }
+  let!(:user) { FactoryGirl.create(:user) }
   let!(:study) { FactoryGirl.create(:study) }
 
   before do
@@ -14,11 +15,13 @@ RSpec.describe "StudyNoteAdmin" do
     click_link "New Study Note"
     fill_in "Notes", with: "Test study note"
     select study.title, from: "Study"
+    select user.name, from: "User"
     click_button "Create Study note"
     expect(page).to have_text "Study note was successfully created"
     note = StudyNote.find_by_notes("Test study note")
     expect(note).not_to be nil
     expect(note.study).to eq study
+    expect(note.user).to eq user
   end
 
   context "with an existing study note" do

--- a/spec/features/contributing_spec.rb
+++ b/spec/features/contributing_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Contributing to a study" do
     expect(document).not_to be nil
     expect(document.document).not_to be nil
     expect(document.study).to eq study
+    expect(document.user).to eq user
 
     expect(study).to have_latest_activity(key: "study.document_added",
                                           owner: user)
@@ -62,6 +63,7 @@ RSpec.describe "Contributing to a study" do
 
     expect(note).not_to be nil
     expect(note.study).to eq study
+    expect(note.user).to eq user
     activity = study.activities.last
     expect(activity.key).to eq "study.study_note_added"
     expect(activity.owner).to eq user
@@ -84,6 +86,7 @@ RSpec.describe "Contributing to a study" do
 
     expect(publication).not_to be nil
     expect(publication.study).to eq study
+    expect(publication.user).to eq user
     expect(study).to have_latest_activity(key: "study.publication_added",
                                           owner: user)
   end
@@ -103,6 +106,7 @@ RSpec.describe "Contributing to a study" do
     expect(dissemination).not_to be nil
     expect(dissemination.fed_back_to_field).to be false
     expect(dissemination.study).to eq study
+    expect(dissemination.user).to eq user
     expect(study).to have_latest_activity(key: "study.dissemination_added",
                                           owner: user)
   end
@@ -125,6 +129,7 @@ RSpec.describe "Contributing to a study" do
     expect(dissemination).not_to be nil
     expect(dissemination.fed_back_to_field).to be true
     expect(dissemination.study).to eq study
+    expect(dissemination.user).to eq user
     expect(study).to have_latest_activity(key: "study.dissemination_added",
                                           owner: user)
   end
@@ -171,6 +176,7 @@ RSpec.describe "Contributing to a study" do
 
     expect(impact).not_to be nil
     expect(impact.study).to eq study
+    expect(impact.user).to eq user
     expect(impact.impact_type).to eq msf_policy_impact_type
 
     expect(study).to have_latest_activity(key: "study.study_impact_added",
@@ -197,10 +203,12 @@ RSpec.describe "Contributing to a study" do
 
     expect(msf_impact).not_to be nil
     expect(msf_impact.study).to eq study
+    expect(msf_impact.user).to eq user
     expect(msf_impact.impact_type).to eq msf_policy_impact_type
 
     expect(program_impact).not_to be nil
     expect(program_impact.study).to eq study
+    expect(program_impact.user).to eq user
     expect(program_impact.impact_type).to eq programme_impact_type
 
     activities = study.activities.first(2)
@@ -229,6 +237,7 @@ RSpec.describe "Contributing to a study" do
 
     expect(enabler_barrier).not_to be nil
     expect(enabler_barrier.study).to eq study
+    expect(enabler_barrier.user).to eq user
     expect(enabler_barrier.enabler_barrier).to eq delivery_barrier
 
     expect(study).to have_latest_activity(
@@ -259,10 +268,12 @@ RSpec.describe "Contributing to a study" do
 
     expect(delivery).not_to be nil
     expect(delivery.study).to eq study
+    expect(delivery.user).to eq user
     expect(delivery.enabler_barrier).to eq delivery_barrier
 
     expect(patient).not_to be nil
     expect(patient.study).to eq study
+    expect(patient.user).to eq user
     expect(patient.enabler_barrier).to eq patient_barrier
 
     activities = study.activities.first(2)

--- a/spec/models/dissemination_spec.rb
+++ b/spec/models/dissemination_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe Dissemination, type: :model do
   it do
     is_expected.to have_db_column(:other_dissemination_category).of_type(:text)
   end
+  it { is_expected.to have_db_column(:user_id).of_type(:integer) }
 
   # Associations
   it { is_expected.to belong_to(:study).inverse_of(:disseminations) }
+  it { is_expected.to belong_to(:user).inverse_of(:disseminations) }
   it do
     is_expected.to belong_to(:dissemination_category).
       inverse_of(:disseminations)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe Document, type: :model do
     is_expected.to have_db_column(:document_type_id).of_type(:integer).
       with_options(null: false)
   end
+  it { is_expected.to have_db_column(:user_id).of_type(:integer) }
 
   it { should have_attached_file(:document) }
 
   # Associations
   it { is_expected.to belong_to(:document_type).inverse_of(:documents) }
   it { is_expected.to belong_to(:study).inverse_of(:documents) }
+  it { is_expected.to belong_to(:user).inverse_of(:documents) }
 
   # Validation
   it { is_expected.to validate_presence_of(:study) }

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -21,9 +21,11 @@ RSpec.describe Publication, type: :model do
     is_expected.to have_db_column(:publication_year).of_type(:integer).
       with_options(null: false)
   end
+  it { is_expected.to have_db_column(:user_id).of_type(:integer) }
 
   # Associations
   it { is_expected.to belong_to(:study).inverse_of(:publications) }
+  it { is_expected.to belong_to(:user).inverse_of(:publications) }
 
   # Validations
   it { is_expected.to validate_presence_of(:lead_author) }

--- a/spec/models/study_enabler_barrier_spec.rb
+++ b/spec/models/study_enabler_barrier_spec.rb
@@ -15,10 +15,15 @@ RSpec.describe StudyEnablerBarrier, type: :model do
     is_expected.to have_db_column(:description).of_type(:text).
       with_options(null: false)
   end
+  it { is_expected.to have_db_column(:user_id).of_type(:integer) }
 
   # Associations
-  it { is_expected.to belong_to(:study) }
-  it { is_expected.to belong_to(:enabler_barrier) }
+  it { is_expected.to belong_to(:study).inverse_of(:study_enabler_barriers) }
+  it do
+    is_expected.to belong_to(:enabler_barrier).
+      inverse_of(:study_enabler_barriers)
+  end
+  it { is_expected.to belong_to(:user).inverse_of(:study_enabler_barriers) }
 
   # Validation
   it { is_expected.to validate_presence_of(:study) }

--- a/spec/models/study_impact_spec.rb
+++ b/spec/models/study_impact_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe StudyImpact, type: :model do
     is_expected.to have_db_column(:description).of_type(:text).
       with_options(null: false)
   end
+  it { is_expected.to have_db_column(:user_id).of_type(:integer) }
 
   # Associations
-  it { is_expected.to belong_to(:study) }
+  it { is_expected.to belong_to(:study).inverse_of(:study_impacts) }
   it { is_expected.to belong_to(:impact_type) }
+  it { is_expected.to belong_to(:user).inverse_of(:study_impacts) }
 
   # Validation
   it { is_expected.to validate_presence_of(:study) }

--- a/spec/models/study_note_spec.rb
+++ b/spec/models/study_note_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe StudyNote, type: :model do
     is_expected.to have_db_column(:notes).of_type(:text).
       with_options(null: false)
   end
+  it { is_expected.to have_db_column(:user_id).of_type(:integer) }
 
   # Associations
   it { is_expected.to belong_to(:study).inverse_of(:study_notes) }
+  it { is_expected.to belong_to(:user).inverse_of(:study_notes) }
 
   # Validation
   it { is_expected.to validate_presence_of(:study) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe User, type: :model do
     is_expected.to have_many(:involved_activities).
       class_name("PublicActivity::Activity")
   end
+  it { is_expected.to have_many(:documents).inverse_of(:user) }
+  it { is_expected.to have_many(:publications).inverse_of(:user) }
+  it { is_expected.to have_many(:disseminations).inverse_of(:user) }
+  it { is_expected.to have_many(:study_impacts).inverse_of(:user) }
+  it { is_expected.to have_many(:study_notes).inverse_of(:user) }
+  it { is_expected.to have_many(:study_enabler_barriers).inverse_of(:user) }
 
   # Validation
   it { is_expected.to validate_presence_of(:name) }

--- a/spec/support/study_contribution_controller_shared_examples.rb
+++ b/spec/support/study_contribution_controller_shared_examples.rb
@@ -1,3 +1,5 @@
+require "support/devise"
+
 RSpec.shared_examples_for "study contribution controller" do
   context "when given valid data" do
     it "creates a resource" do
@@ -14,6 +16,28 @@ RSpec.shared_examples_for "study contribution controller" do
     it "sets a flash notice" do
       post :create, valid_attributes
       expect(flash[:notice]).to eq expected_success_message
+    end
+
+    context "when a user is logged in" do
+      before do
+        sign_in user
+      end
+
+      it "assigns the user to the resource" do
+        post :create, valid_attributes
+        expect(association.last.user).to eq user
+      end
+    end
+
+    context "when no user is logged in" do
+      before do
+        sign_out :user
+      end
+
+      it "assigns no user to the resource" do
+        post :create, valid_attributes
+        expect(association.last.user).to be_nil
+      end
     end
   end
 

--- a/spec/support/study_multiple_resources_controller_shared_examples.rb
+++ b/spec/support/study_multiple_resources_controller_shared_examples.rb
@@ -16,6 +16,28 @@ RSpec.shared_examples_for(
       post action, valid_attributes
       expect(flash[:notice]).to eq expected_success_message
     end
+
+    context "when a user is logged in" do
+      before do
+        sign_in user
+      end
+
+      it "assigns the user to the resource" do
+        post action, valid_attributes
+        expect(association.last.user).to eq user
+      end
+    end
+
+    context "when no user is logged in" do
+      before do
+        sign_out :user
+      end
+
+      it "assigns no user to the resource" do
+        post action, valid_attributes
+        expect(association.last.user).to be_nil
+      end
+    end
   end
 
   context "when given invalid data" do
@@ -84,6 +106,30 @@ RSpec.shared_examples_for(
     it "sets a flash notice" do
       post action, valid_attributes
       expect(flash[:notice]).to eq expected_success_message
+    end
+
+    context "when a user is logged in" do
+      before do
+        sign_in user
+      end
+
+      it "assigns the user to the resources" do
+        post action, valid_attributes
+        expect(association.last.user).to eq user
+        expect(association[-2].user).to eq user
+      end
+    end
+
+    context "when no user is logged in" do
+      before do
+        sign_out :user
+      end
+
+      it "assigns no user to the resource" do
+        post action, valid_attributes
+        expect(association.last.user).to be_nil
+        expect(association[-2].user).to be nil
+      end
     end
   end
 


### PR DESCRIPTION
- Adds a user field to documents, publications, etc
- Automatically fills that field in with the current_user when they're added
to a study from the study page
- Allows admins to see the user and edit them from the admin pages

I purposely made this optional for now, until we require people to log in to
see the contribution forms.

Closes #102