### PR TITLE
Archive studies that completed over 12 months ago

### DIFF
--- a/app/controllers/concerns/listing_studies.rb
+++ b/app/controllers/concerns/listing_studies.rb
@@ -1,0 +1,19 @@
+module ListingStudies
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_include_archived, only: :index
+    before_action :set_study_scope, only: :index
+  end
+
+  def set_include_archived
+    @include_archived = params[:include_archived] == "1"
+  end
+
+  def set_study_scope
+    @study_scope = :not_archived_or_withdrawn
+    if @include_archived
+      @study_scope = :not_withdrawn
+    end
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,12 @@
 class HomeController < ApplicationController
+  include ListingStudies
+
   def index
-    @studies = Study.order(updated_at: :desc).page(params[:page]).per(10)
-    @total_studies = Study.count
+    # rubocop:disable Style/MultilineOperationIndentation
+    @studies = Study.send(@study_scope).
+                     order(updated_at: :desc).
+                     page(params[:page]).
+                     per(10)
+    # rubocop:enable Style/MultilineOperationIndentation
   end
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -1,10 +1,17 @@
 class StudiesController < ApplicationController
+  include ListingStudies
+
   before_action :set_and_authenticate_user, only: :index
 
   def index
     page = params[:page]
-    @studies = @user.studies.order(updated_at: :desc).page(page).per(10)
-    @total_studies = @user.studies.count
+    # rubocop:disable Style/MultilineOperationIndentation
+    @studies = @user.studies.
+                     send(@study_scope).
+                     order(updated_at: :desc).
+                     page(page).
+                     per(10)
+    # rubocop:enable Style/MultilineOperationIndentation
     render "home/index"
   end
 

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -11,6 +11,15 @@
             <a href="/search?erb=expiring" class="quick-filters__filter quick-filters__filter--expiring">
                 Studies with ERB approval expiring
             </a>
+          <% if @include_archived %>
+            <a href="?include_archived=0" class="quick-filters__filter quick-filters__filter--archived">
+                Exclude archived studies
+            </a>
+          <% else %>
+            <a href="?include_archived=1" class="quick-filters__filter quick-filters__filter--archived">
+                Include archived studies
+            </a>
+          <% end %>
         </div>
     </div>
     <div class="list-of-things__secondary-action list-of-things__secondary-action--filters">

--- a/lib/tasks/load_msf_spreadsheet.rake
+++ b/lib/tasks/load_msf_spreadsheet.rake
@@ -37,6 +37,13 @@ task :load_msf_spreadsheet, [:csv_file] => [:environment] do |_t, args|
       date = Date.strptime(row[:concept_paper_date], "%d/%m/%Y")
     end
 
+    if row[:data_collection_completed_date].blank?
+      completed_date = nil
+    else
+      completed_date = Date.strptime(row[:data_collection_completed_date],
+                                     "%d/%m/%Y")
+    end
+
     country_codes = []
     unless row[:study_location].blank?
       study_locations = row[:study_location].split(",")
@@ -97,7 +104,8 @@ task :load_msf_spreadsheet, [:csv_file] => [:environment] do |_t, args|
       country_codes: country_codes,
       erb_reference: erb_reference,
       erb_status: erb_status,
-      principal_investigator: pi
+      principal_investigator: pi,
+      completed: completed_date
     )
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -73,6 +73,24 @@ RSpec.describe ApplicationHelper, type: :helper do
           expect(study_timeline(study)).to eq expected_withdrawn_timeline
         end
       end
+
+      context "when the study is archived" do
+        let(:study) do
+          FactoryGirl.create(:study, study_stage: "completion",
+                                     completed: Time.zone.today - 366.days,
+                                     erb_status: accept_status)
+        end
+
+        it "returns a timeline with multiple entries" do
+          expected_timeline = base_timeline
+          expected_timeline[:concept][:state] = "done"
+          expected_timeline[:protocol_erb][:state] = "done"
+          expected_timeline[:delivery][:state] = "done"
+          expected_timeline[:completion][:state] = "done"
+          expected_timeline[:archived] = { label: "Archived", state: "doing" }
+          expect(study_timeline(study)).to eq expected_timeline
+        end
+      end
     end
 
     context "given a study with history" do
@@ -174,6 +192,29 @@ RSpec.describe ApplicationHelper, type: :helper do
             label: "Withdrawn or Postponed",
             state: "doing"
           }
+          expect(study_timeline(study)).to eq expected_timeline
+        end
+      end
+
+      context "when the study is archived" do
+        let(:study) { FactoryGirl.create(:study) }
+
+        it "returns a timeline with multiple entries" do
+          study.study_stage = "protocol_erb"
+          study.erb_status = accept_status
+          study.save!
+          study.study_stage = "delivery"
+          study.save!
+          study.study_stage = "completion"
+          study.completed = Time.zone.today - 366.days
+          study.save!
+
+          expected_timeline = base_timeline
+          expected_timeline[:concept][:state] = "done"
+          expected_timeline[:protocol_erb][:state] = "done"
+          expected_timeline[:delivery][:state] = "done"
+          expected_timeline[:completion][:state] = "done"
+          expected_timeline[:archived] = { label: "Archived", state: "doing" }
           expect(study_timeline(study)).to eq expected_timeline
         end
       end

--- a/spec/support/study_listing_controller_shared_examples.rb
+++ b/spec/support/study_listing_controller_shared_examples.rb
@@ -11,8 +11,39 @@ RSpec.shared_examples_for "study listing controller" do
     expect(assigns[:studies]).to match_array(studies.first(10))
   end
 
-  it "sets total_studies" do
-    get action, params
-    expect(assigns[:total_studies]).to eq 20
+  describe "#set_study_scope" do
+    it "sets study_scope" do
+      get action, params
+      expect(assigns[:study_scope]).to eq :not_archived_or_withdrawn
+    end
+
+    context "when the user asks for archived studies too" do
+      before do
+        params[:include_archived] = 1
+      end
+
+      it "sets study_scope" do
+        get action, params
+        expect(assigns[:study_scope]).to eq :not_withdrawn
+      end
+    end
+  end
+
+  describe "#set_include_archived" do
+    it "sets include_archived" do
+      get action, params
+      expect(assigns[:include_archived]).to be false
+    end
+
+    context "when the user asks for archived studies too" do
+      before do
+        params[:include_archived] = 1
+      end
+
+      it "sets study_scope" do
+        get action, params
+        expect(assigns[:include_archived]).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
This:
- Adds some scopes for retrieving/excluding archived and withdrawn studies
  from queries
- Adds an archived? helper on the Study model
- Imports the completed date from MSF's spreadsheet during data import
- Shows the archived status as an extra stage in the study timeline
- Excludes withdrawn and archived studies from the study listing pages
- Adds a link to include archived studies again (withdrawn studies are always
  hidden now)

Closes #64
For #1 and #2