### PR TITLE
Allow PIs, RMs and Admins to progress studies from protocol -> delivery -> completion

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -2,6 +2,10 @@ class StudiesController < ApplicationController
   include ListingStudies
 
   before_action :set_and_authenticate_user, only: :index
+  before_action :set_study, only: [:progress_to_delivery,
+                                   :progress_to_completion]
+  before_action :check_user_can_manage_study, only: [:progress_to_delivery,
+                                                     :progress_to_completion]
 
   def index
     page = params[:page]
@@ -24,7 +28,34 @@ class StudiesController < ApplicationController
     @study_impacts = {}
   end
 
+  def progress_to_delivery
+    if @study.protocol_erb?
+      @study.study_stage = "delivery"
+      @study.save!
+    end
+    flash[:notice] = "Study stage updated successfully"
+    redirect_to study_path(@study)
+  rescue
+    flash[:alert] = "Sorry, we couldn't update the study, please try again"
+  end
+
+  def progress_to_completion
+    if @study.delivery?
+      @study.study_stage = "completion"
+      @study.completed = Time.zone.today
+      @study.save!
+    end
+    flash[:notice] = "Study stage updated successfully"
+    redirect_to study_path(@study)
+  rescue
+    flash[:alert] = "Sorry, we couldn't update the study, please try again"
+  end
+
   protected
+
+  def set_study
+    @study = Study.find(params[:study_id])
+  end
 
   def set_and_authenticate_user
     if current_user.nil?
@@ -32,6 +63,15 @@ class StudiesController < ApplicationController
     end
     @user = User.find(params[:user_id])
     unless @user == current_user || current_user.is_admin
+      forbidden
+    end
+  end
+
+  def check_user_can_manage_study
+    if current_user.nil?
+      return redirect_to new_user_session_path
+    end
+    unless @study.user_can_manage?(current_user)
       forbidden
     end
   end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -311,4 +311,11 @@ class Study < ActiveRecord::Base
   def erb_status_needed?
     protocol_needed && !(concept? || withdrawn_postponed?)
   end
+
+  # Can the supplied user manage this study?
+  # e.g. change the study stage or invite people to edit it
+  def user_can_manage?(user)
+    return false if user.blank?
+    user.is_admin || research_manager == user || principal_investigator == user
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <%= csrf_meta_tag %>
         <title>
           <% if content_for :page_title %>
             <%= content_for :page_title %> – ReMIT

--- a/app/views/public_activity/study/_completed_changed.html.erb
+++ b/app/views/public_activity/study/_completed_changed.html.erb
@@ -1,0 +1,11 @@
+<% content_for :extra_classes, flush: true do %> <% end %>
+
+<% content_for :title, flush: true do %>
+    Completed date changed<%= " by #{a.owner.name}" unless a.owner.blank? %>
+<% end %>
+
+<% content_for :description, flush: true do %>
+    <p class="timeline__item__details">
+        Changed to <strong>&ldquo;<%= p[:after] %>&rdquo;</strong>.
+    </p>
+<% end %>

--- a/app/views/public_activity/study/_local_erb_approved.html.erb
+++ b/app/views/public_activity/study/_local_erb_approved.html.erb
@@ -1,0 +1,11 @@
+<% content_for :extra_classes, flush: true do %> <% end %>
+
+<% content_for :title, flush: true do %>
+    ERB approval date changed<%= " by #{a.owner.name}" unless a.owner.blank? %>
+<% end %>
+
+<% content_for :description, flush: true do %>
+    <p class="timeline__item__details">
+        Changed to <strong>&ldquo;<%= p[:after] %>&rdquo;</strong>.
+    </p>
+<% end %>

--- a/app/views/public_activity/study/_local_erb_submitted_changed.html.erb
+++ b/app/views/public_activity/study/_local_erb_submitted_changed.html.erb
@@ -1,0 +1,11 @@
+<% content_for :extra_classes, flush: true do %> <% end %>
+
+<% content_for :title, flush: true do %>
+    ERB submission date changed<%= " by #{a.owner.name}" unless a.owner.blank? %>
+<% end %>
+
+<% content_for :description, flush: true do %>
+    <p class="timeline__item__details">
+        Changed to <strong>&ldquo;<%= p[:after] %>&rdquo;</strong>.
+    </p>
+<% end %>

--- a/app/views/studies/show.html.erb
+++ b/app/views/studies/show.html.erb
@@ -82,6 +82,31 @@
                 </div>
             </div>
             <div class="study-main__secondary">
+              <% if %w(protocol_erb delivery).include?(@study.study_stage) && @study.user_can_manage?(current_user)%>
+                <div class="study-main__secondary__section study-main__secondary__section--admin">
+                    <h3>Manage this study:</h3>
+                    <ul>
+                      <% if @study.study_stage == 'protocol_erb' %>
+                        <li>
+                            <%= link_to study_progress_to_delivery_path(@study),
+                                        class: "btn btn-default",
+                                        method: :put do %>
+                                <span class="glyphicon glyphicon-transfer"></span> This study is in delivery
+                            <% end %>
+                        </li>
+                      <% elsif @study.study_stage == 'delivery' %>
+                        <li>
+                            <%= link_to study_progress_to_completion_path(@study),
+                                        class: "btn btn-default",
+                                        method: :put do %>
+                                <span class="glyphicon glyphicon-transfer"></span> This study has completed
+                            <% end %>
+                        </li>
+                      <% end %>
+                    </ul>
+                </div>
+              <% end %>
+
                 <div class="study-main__secondary__section">
                     <h3>Documents:</h3>
                   <% if @study.documents.each do |document| %>
@@ -97,6 +122,7 @@
                     <p class="study-main__secondary__section__blank">No documents uploaded.</p>
                   <% end %>
                 </div>
+
                 <div class="study-main__secondary__section">
                     <h3>Publications:</h3>
                   <% if @study.publications.each do |publication| %>
@@ -114,11 +140,13 @@
                     <p class="study-main__secondary__section__blank">No publications recorded.</p>
                   <% end %>
                 </div>
+
                 <div class="study-main__secondary__section">
                     <h3>Follow this study:</h3>
                     <p>Be notified when there is activity on this study.</p>
                     <p><a href="#" class="btn btn-success">Follow this study</a></p>
                 </div>
+
               <% if user_signed_in? && current_user.is_admin %>
                 <div class="study-main__secondary__section study-main__secondary__section--admin">
                     <h3>Admin actions:</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
     resources :study_enabler_barriers do
       post :create_multiple, on: :collection
     end
+    put "progress_to_delivery"
+    put "progress_to_completion"
   end
 
   # Users only have a list of studies at the moment, devise takes care of the

--- a/spec/features/study_page_spec.rb
+++ b/spec/features/study_page_spec.rb
@@ -1,0 +1,104 @@
+# encoding: utf-8
+require "rails_helper"
+require "support/user_account_feature_helper"
+
+RSpec.describe "Study page" do
+  let(:study) { FactoryGirl.create(:study) }
+
+  it "exists" do
+    visit study_path(study)
+    expect(page).to have_text(study.title)
+  end
+
+  context "when the user is an admin" do
+    let(:admin) { FactoryGirl.create(:admin_user) }
+
+    it "lets you edit the study in the admin" do
+      sign_in_account(admin.email)
+      visit study_path(study)
+      click_link("Edit study details")
+      expect(current_path).to eq edit_admin_study_path(study)
+    end
+  end
+
+  describe "editing the study stage" do
+    let(:pi) { FactoryGirl.create(:user) }
+    let(:rm) { FactoryGirl.create(:user) }
+    let(:admin) { FactoryGirl.create(:admin_user) }
+    let(:other) { FactoryGirl.create(:user) }
+
+    before do
+      study.principal_investigator = pi
+      study.research_manager = rm
+      study.save!
+    end
+
+    context "when the study is in the protocol_erb stage" do
+      before do
+        study.study_stage = "protocol_erb"
+        study.protocol_needed = true
+        study.erb_status = FactoryGirl.create(:accept)
+        study.save!
+      end
+
+      it "can be progressed to the delivery stage by allowed users" do
+        [pi, rm, admin].each do |user|
+          sign_in_account(user.email)
+          visit study_path(study)
+          click_link "This study is in delivery"
+          expect(page).to have_text "Study stage updated successfully"
+          expect(study.reload.delivery?).to be true
+          # We have to reset the study for each user
+          sign_out
+          study.study_stage = "protocol_erb"
+          study.save!
+        end
+      end
+
+      it "is hidden from other users" do
+        sign_in_account(other.email)
+        visit study_path(study)
+        expect(page).not_to have_text("This study is in delivery")
+      end
+
+      it "is hidden from anonymous users" do
+        visit study_path(study)
+        expect(page).not_to have_text("This study is in delivery")
+      end
+    end
+
+    context "when the study is in the delivery stage" do
+      before do
+        study.study_stage = "delivery"
+        study.protocol_needed = true
+        study.erb_status = FactoryGirl.create(:accept)
+        study.save!
+      end
+
+      it "can be progressed to the completion stage by allowed users" do
+        [pi, rm, admin].each do |user|
+          sign_in_account(user.email)
+          visit study_path(study)
+          click_link "This study has completed"
+          expect(page).to have_text "Study stage updated successfully"
+          expect(study.reload.completion?).to be true
+          # We have to reset the study for each user
+          sign_out
+          study.study_stage = "delivery"
+          study.save!
+        end
+      end
+
+      it "is hidden from other users" do
+        sign_in_account(other.email)
+        visit study_path(study)
+        expect(page).not_to have_text("This study has completed")
+      end
+
+      it "is hidden from anonymous users" do
+        visit study_path(study)
+        expect(page).not_to have_text("This study has completed")
+      end
+    end
+  end
+end

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -865,4 +865,48 @@ RSpec.describe Study, type: :model do
       expect(Study.erb_response_overdue).to match_array(expected)
     end
   end
+
+  describe "#user_can_manage?" do
+    let(:study) { FactoryGirl.create(:study) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    context "when the user is not related to the study" do
+      it "returns false" do
+        expect(study.user_can_manage?(user)).to be false
+      end
+    end
+
+    context "when the user is the study pi" do
+      before do
+        study.principal_investigator = user
+        study.save!
+      end
+
+      it "returns true" do
+        expect(study.user_can_manage?(user)).to be true
+      end
+    end
+
+    context "when the user is the study rm" do
+      before do
+        study.research_manager = user
+        study.save!
+      end
+
+      it "returns true" do
+        expect(study.user_can_manage?(user)).to be true
+      end
+    end
+
+    context "when the user is an admin" do
+      before do
+        user.is_admin = true
+        user.save!
+      end
+
+      it "returns true" do
+        expect(study.user_can_manage?(user)).to be true
+      end
+    end
+  end
 end

--- a/spec/support/user_account_feature_helper.rb
+++ b/spec/support/user_account_feature_helper.rb
@@ -18,3 +18,7 @@ def sign_in_account(email, password = "password")
   fill_in "Password", with: password
   click_button "Log in"
 end
+
+def sign_out
+  click_link "Sign Out"
+end


### PR DESCRIPTION
This adds a link to the study page to update the study stage to delivery or
completion. It also adds a couple of missing activity templates, and a new
method to the Study model that helps figure out if a user is allowed to do
things like update the stages.

Closes #110

For #3