### PR TITLE
Dashboard Searching/Filtering

### DIFF
--- a/app/controllers/concerns/listing_studies.rb
+++ b/app/controllers/concerns/listing_studies.rb
@@ -5,6 +5,7 @@ module ListingStudies
     before_action :set_include_archived, only: :index
     before_action :set_study_scope, only: :index
     before_action :set_filter_form_values, only: :index
+    before_action :set_ordering, only: :index
   end
 
   def set_include_archived
@@ -36,6 +37,18 @@ module ListingStudies
     @study_setting = nil
     @country = nil
   end
+
+  def set_ordering
+    case params[:order]
+    when "updated"
+      @ordering = {updated_at: :desc}
+    when "created"
+      @ordering = {created_at: :desc}
+    else
+      @ordering = {updated_at: :desc}
+    end
+  end
+
 
   def get_filtered_studies
     studies = Study.send(@study_scope)

--- a/app/controllers/concerns/listing_studies.rb
+++ b/app/controllers/concerns/listing_studies.rb
@@ -40,10 +40,6 @@ module ListingStudies
   def get_filtered_studies
     studies = Study.send(@study_scope)
 
-    unless params[:pi].blank?
-      studies = studies.joins(:principal_investigator).where('lower("users"."name") = ?', params[:pi].downcase)
-    end
-
     unless params[:study_type].blank?
       studies = studies.joins(:study_type).where('lower("study_types"."name") = ?', params[:study_type].downcase)
       @study_type = params[:study_type].downcase

--- a/app/controllers/concerns/listing_studies.rb
+++ b/app/controllers/concerns/listing_studies.rb
@@ -4,6 +4,7 @@ module ListingStudies
   included do
     before_action :set_include_archived, only: :index
     before_action :set_study_scope, only: :index
+    before_action :set_filter_form_values, only: :index
   end
 
   def set_include_archived
@@ -15,5 +16,23 @@ module ListingStudies
     if @include_archived
       @study_scope = :not_withdrawn
     end
+  end
+
+  def set_filter_form_values
+    @study_types = StudyType.all.order(name: :asc)
+  end
+
+  def get_filtered_studies
+    studies = Study.send(@study_scope)
+
+    unless params[:pi].blank?
+      studies = studies.joins(:principal_investigator).where('lower("users"."name") = ?', params[:pi].downcase)
+    end
+
+    unless params[:study_type].blank?
+      studies = studies.joins(:study_type).where('lower("study_types"."name") = ?', params[:study_type].downcase)
+    end
+
+    studies
   end
 end

--- a/app/controllers/concerns/listing_studies.rb
+++ b/app/controllers/concerns/listing_studies.rb
@@ -20,6 +20,11 @@ module ListingStudies
 
   def set_filter_form_values
     @study_types = StudyType.all.order(name: :asc)
+
+    # These indicate the current filter in use, if any, and will be
+    # set appropriately by get_filtered_studies
+    @study_type = nil
+    @study_stage = nil
   end
 
   def get_filtered_studies
@@ -31,6 +36,12 @@ module ListingStudies
 
     unless params[:study_type].blank?
       studies = studies.joins(:study_type).where('lower("study_types"."name") = ?', params[:study_type].downcase)
+      @study_type = params[:study_type].downcase
+    end
+
+    unless params[:study_stage].blank?
+      studies = studies.where(study_stage: params[:study_stage])
+      @study_stage = params[:study_stage].downcase
     end
 
     studies

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,10 +3,9 @@ class HomeController < ApplicationController
 
   def index
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = get_filtered_studies.
-                 order(@ordering).
-                 page(params[:page]).
-                 per(10)
+    @studies = get_filtered_studies.order(@ordering).
+                                    page(params[:page]).
+                                    per(10)
     # rubocop:enable Style/MultilineOperationIndentation
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,7 @@ class HomeController < ApplicationController
   def index
     # rubocop:disable Style/MultilineOperationIndentation
     @studies = get_filtered_studies.
-                 order(updated_at: :desc).
+                 order(@ordering).
                  page(params[:page]).
                  per(10)
     # rubocop:enable Style/MultilineOperationIndentation

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,10 +3,10 @@ class HomeController < ApplicationController
 
   def index
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = Study.send(@study_scope).
-                     order(updated_at: :desc).
-                     page(params[:page]).
-                     per(10)
+    @studies = get_filtered_studies.
+                 order(updated_at: :desc).
+                 page(params[:page]).
+                 per(10)
     # rubocop:enable Style/MultilineOperationIndentation
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,14 +2,8 @@ class SearchController < ApplicationController
   include ListingStudies
 
   def index
-    studies = Study.send(@study_scope)
-
-    unless params[:pi].blank?
-      studies = studies.joins(:principal_investigator).where('lower(users.name) = ?', params[:pi].downcase)
-    end
-
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = studies.
+    @studies = get_filtered_studies.
                  order(updated_at: :desc).
                  page(params[:page]).
                  per(10)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,7 +4,7 @@ class SearchController < ApplicationController
   def index
     # rubocop:disable Style/MultilineOperationIndentation
     @studies = get_search_results.
-                 order(updated_at: :desc).
+                 order(@ordering).
                  page(params[:page]).
                  per(10)
     # rubocop:enable Style/MultilineOperationIndentation

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,11 +2,17 @@ class SearchController < ApplicationController
   include ListingStudies
 
   def index
+    studies = Study.send(@study_scope)
+
+    unless params[:pi].blank?
+      studies = studies.joins(:principal_investigator).where('lower(users.name) = ?', params[:pi].downcase)
+    end
+
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = Study.send(@study_scope).
-                     order(updated_at: :desc).
-                     page(params[:page]).
-                     per(10)
+    @studies = studies.
+                 order(updated_at: :desc).
+                 page(params[:page]).
+                 per(10)
     # rubocop:enable Style/MultilineOperationIndentation
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,10 +3,9 @@ class SearchController < ApplicationController
 
   def index
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = get_search_results.
-                 order(@ordering).
-                 page(params[:page]).
-                 per(10)
+    @studies = get_search_results.order(@ordering).
+                                  page(params[:page]).
+                                  per(10)
     # rubocop:enable Style/MultilineOperationIndentation
   end
 
@@ -49,7 +48,7 @@ class SearchController < ApplicationController
       # Match reference number. We do this exactly because it's quite short
       # and so a LIKE could bring up lots of false positives
       reference_number_sql = 'lower("reference_number") = ?'
-      queries << studies.where(reference_number_sql, "#{@q.downcase}").to_sql
+      queries << studies.where(reference_number_sql, @q.downcase).to_sql
 
       sql = "(#{queries.join(' UNION ')}) AS studies"
       studies = Study.from(sql)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -49,7 +49,7 @@ class SearchController < ApplicationController
       # Match reference number. We do this exactly because it's quite short
       # and so a LIKE could bring up lots of false positives
       reference_number_sql = 'lower("reference_number") = ?'
-      queries << studies.where(reference_number_sql, q_param).to_sql
+      queries << studies.where(reference_number_sql, "#{@q.downcase}").to_sql
 
       sql = "(#{queries.join(' UNION ')}) AS studies"
       studies = Study.from(sql)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -23,29 +23,33 @@ class SearchController < ApplicationController
       # ordering etc.
       queries = []
 
+      q_param = "%#{@q.downcase}%"
+
       # Match PI name
-      queries << studies.joins(:principal_investigator).where(
-                  'lower("users"."name") LIKE ?',
-                  "%#{@q.downcase}%"
-                ).to_sql
+      pi_sql = 'lower("users"."name") LIKE ?'
+      # rubocop:disable Style/MultilineOperationIndentation
+      queries << studies.joins(:principal_investigator).
+                         where(pi_sql, q_param).
+                         to_sql
+      # rubocop:enable Style/MultilineOperationIndentation
 
       # Match study topic name
-      queries << studies.joins(:study_topics).where(
-                  'lower("study_topics"."name") LIKE ?',
-                  "%#{@q.downcase}%"
-                ).to_sql
+      topic_sql = 'lower("study_topics"."name") LIKE ?'
+      queries << studies.joins(:study_topics).where(topic_sql, q_param).to_sql
 
       # Match study title
-      queries << studies.where(
-                  'lower("title") LIKE ?',
-                  "%#{@q.downcase}%"
-                ).to_sql
+      queries << studies.where('lower("title") LIKE ?', q_param).to_sql
 
       # Match country name
       country = ISO3166::Country.find_country_by_name(@q)
       unless country.nil?
         queries << studies.in_country(country.alpha2).to_sql
       end
+
+      # Match reference number. We do this exactly because it's quite short
+      # and so a LIKE could bring up lots of false positives
+      reference_number_sql = 'lower("reference_number") = ?'
+      queries << studies.where(reference_number_sql, q_param).to_sql
 
       sql = "(#{queries.join(' UNION ')}) AS studies"
       studies = Study.from(sql)

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,10 +3,54 @@ class SearchController < ApplicationController
 
   def index
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = get_filtered_studies.
+    @studies = get_search_results.
                  order(updated_at: :desc).
                  page(params[:page]).
                  per(10)
     # rubocop:enable Style/MultilineOperationIndentation
+  end
+
+  protected
+
+  def get_search_results
+    studies = get_filtered_studies
+
+    @q = params[:q]
+    unless @q.blank?
+      # We want to find Studies that match the query on many fields, so build a
+      # query using UNION. Building the list of results as an array wouldn't be
+      # suitable because we need an ActiveRecord_Relation for pagination,
+      # ordering etc.
+      queries = []
+
+      # Match PI name
+      queries << studies.joins(:principal_investigator).where(
+                  'lower("users"."name") LIKE ?',
+                  "%#{@q.downcase}%"
+                ).to_sql
+
+      # Match study topic name
+      queries << studies.joins(:study_topics).where(
+                  'lower("study_topics"."name") LIKE ?',
+                  "%#{@q.downcase}%"
+                ).to_sql
+
+      # Match study title
+      queries << studies.where(
+                  'lower("title") LIKE ?',
+                  "%#{@q.downcase}%"
+                ).to_sql
+
+      # Match country name
+      country = ISO3166::Country.find_country_by_name(@q)
+      unless country.nil?
+        queries << studies.in_country(country.alpha2).to_sql
+      end
+
+      sql = "(#{queries.join(' UNION ')}) AS studies"
+      studies = Study.from(sql)
+    end
+
+    studies
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,12 @@
+class SearchController < ApplicationController
+  include ListingStudies
+
+  def index
+    # rubocop:disable Style/MultilineOperationIndentation
+    @studies = Study.send(@study_scope).
+                     order(updated_at: :desc).
+                     page(params[:page]).
+                     per(10)
+    # rubocop:enable Style/MultilineOperationIndentation
+  end
+end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -10,12 +10,10 @@ class StudiesController < ApplicationController
   def index
     page = params[:page]
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = get_filtered_studies.
-                 where(principal_investigator_id: @user.id).
-                 send(@study_scope).
-                 order(@ordering).
-                 page(page).
-                 per(10)
+    @studies = get_filtered_studies.where(principal_investigator_id: @user.id).
+                                    order(@ordering).
+                                    page(page).
+                                    per(10)
     # rubocop:enable Style/MultilineOperationIndentation
     render "home/index"
   end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -13,7 +13,7 @@ class StudiesController < ApplicationController
     @studies = get_filtered_studies.
                  where(principal_investigator_id: @user.id).
                  send(@study_scope).
-                 order(updated_at: :desc).
+                 order(@ordering).
                  page(page).
                  per(10)
     # rubocop:enable Style/MultilineOperationIndentation

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -10,11 +10,12 @@ class StudiesController < ApplicationController
   def index
     page = params[:page]
     # rubocop:disable Style/MultilineOperationIndentation
-    @studies = @user.studies.
-                     send(@study_scope).
-                     order(updated_at: :desc).
-                     page(page).
-                     per(10)
+    @studies = get_filtered_studies.
+                 where(principal_investigator_id: @user.id).
+                 send(@study_scope).
+                 order(updated_at: :desc).
+                 page(page).
+                 per(10)
     # rubocop:enable Style/MultilineOperationIndentation
     render "home/index"
   end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -163,6 +163,10 @@ class Study < ActiveRecord::Base
     impactful.uniq.count
   end
 
+  def self.in_country(code)
+    where("country_codes LIKE ?", "%#{code}%")
+  end
+
   # Is this study archived?
   # Things get automatically archived after they've been completed for more
   # than a year

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -171,7 +171,7 @@ class Study < ActiveRecord::Base
   # Things get automatically archived after they've been completed for more
   # than a year
   def archived?
-    return false if completed.nil?
+    return false if completed.nil? || study_stage != "completion"
     completed < Study.archive_date
   end
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "Search Studies" %>
+<%= render partial: "shared/header" %>
+<%= render partial: "shared/subnav" %>
+
+<div class="site-main">
+    <div class="container">
+        <div class="list-of-things">
+            <%= render partial: "shared/list_of_things" %>
+            <%= render partial: "shared/list_of_things_sidebar" %>
+        </div>
+    </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,7 @@
                 with recorded impact
             </h2>
         </div>
-        <form class="site-header__search" action="/search" method="get">
+        <form class="site-header__search" action="<%= search_path %>" method="get">
             <label for="header-search">
                 Search by topic, researcher, or location
             </label>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
                 Search by topic, researcher, or location
             </label>
             <div class="site-header__search__wrapper">
-                <input id="header-search" class="form-control">
+                <input id="header-search" class="form-control" name="q">
                 <button type="submit">Search</button>
             </div>
         </form>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,7 +15,7 @@
                 Search by topic, researcher, or location
             </label>
             <div class="site-header__search__wrapper">
-                <input id="header-search" class="form-control" name="q">
+                <input id="header-search" class="form-control" name="q" value="<%= @q %>">
                 <button type="submit">Search</button>
             </div>
         </form>

--- a/app/views/shared/_list_of_things.html.erb
+++ b/app/views/shared/_list_of_things.html.erb
@@ -10,7 +10,7 @@
         <dl class="dl-horizontal">
             <dt>Study details</dt>
             <dd>
-                <a href="/search?methodology=cohort%20study"><%= study.study_type.name %></a>
+                <a href="/search?study_type=<%= study.study_type.name.downcase %>"><%= study.study_type.name %></a>
               <% unless study.country_names.blank? %>
                 in
                 <a href="/search?location=ethiopia"><%= study.country_names %></a>

--- a/app/views/shared/_list_of_things.html.erb
+++ b/app/views/shared/_list_of_things.html.erb
@@ -21,7 +21,7 @@
           <% unless study.principal_investigator.blank? %>
             <dt>Principal investigator:</dt>
             <dd>
-                <%= link_to study.principal_investigator.name, search_path(pi: study.principal_investigator.name.downcase) %>
+                <%= link_to study.principal_investigator.name, search_path(q: study.principal_investigator.name.downcase) %>
             </dd>
           <% end %>
         </dl>

--- a/app/views/shared/_list_of_things.html.erb
+++ b/app/views/shared/_list_of_things.html.erb
@@ -19,7 +19,7 @@
           <% unless study.principal_investigator.blank? %>
             <dt>Principal investigator:</dt>
             <dd>
-                <a href="/search?pi=irwan%20pirou"><%= study.principal_investigator.name %></a>
+                <a href="/search?pi=<%= study.principal_investigator.name.downcase %>"><%= study.principal_investigator.name %></a>
             </dd>
           <% end %>
         </dl>

--- a/app/views/shared/_list_of_things.html.erb
+++ b/app/views/shared/_list_of_things.html.erb
@@ -1,7 +1,7 @@
 <div class="list-of-things__primary">
     <%= render partial: "shared/list_of_things_sorting" %>
     <div class="list-of-things__list">
-      <% @studies.each do |study| %>
+      <% if @studies.each do |study| %>
         <div class="list-of-things__list__item list-of-things__list__item--study">
             <p class="list-of-things__list__item__badge list-of-things__list__item__badge--completed"><%= study.study_stage_label %></p>
         <h2 class="list-of-things__list__item__title">
@@ -25,6 +25,13 @@
             </dd>
           <% end %>
         </dl>
+        </div>
+      <% end.empty? %>
+        <div class="list-of-things__list__item list-of-things__list__item--study">
+          <p>
+            Sorry, there are no studies that match your criteria. Perhaps try
+            removing some filters or searching for something less specific?
+          </p>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_list_of_things.html.erb
+++ b/app/views/shared/_list_of_things.html.erb
@@ -10,7 +10,7 @@
         <dl class="dl-horizontal">
             <dt>Study details</dt>
             <dd>
-                <%= link_to study.study_type.name, search_path(study_type: study.study_type.name.downcase) %>
+                <%= link_to study.study_type.name, search_path(study_type: study.study_type.name) %>
               <% unless study.country_names.blank? %>
                 in
                 <% study.countries.each do |country| %>
@@ -21,7 +21,7 @@
           <% unless study.principal_investigator.blank? %>
             <dt>Principal investigator:</dt>
             <dd>
-                <%= link_to study.principal_investigator.name, search_path(q: study.principal_investigator.name.downcase) %>
+                <%= link_to study.principal_investigator.name, search_path(q: study.principal_investigator.name) %>
             </dd>
           <% end %>
         </dl>

--- a/app/views/shared/_list_of_things.html.erb
+++ b/app/views/shared/_list_of_things.html.erb
@@ -10,16 +10,18 @@
         <dl class="dl-horizontal">
             <dt>Study details</dt>
             <dd>
-                <a href="/search?study_type=<%= study.study_type.name.downcase %>"><%= study.study_type.name %></a>
+                <%= link_to study.study_type.name, search_path(study_type: study.study_type.name.downcase) %>
               <% unless study.country_names.blank? %>
                 in
-                <a href="/search?location=ethiopia"><%= study.country_names %></a>
+                <% study.countries.each do |country| %>
+                  <%= link_to country.name, search_path(country: country.alpha2) %><%= "," unless country == study.countries.last %>
+                <% end %>
               <% end %>
             </dd>
           <% unless study.principal_investigator.blank? %>
             <dt>Principal investigator:</dt>
             <dd>
-                <a href="/search?pi=<%= study.principal_investigator.name.downcase %>"><%= study.principal_investigator.name %></a>
+                <%= link_to study.principal_investigator.name, search_path(pi: study.principal_investigator.name.downcase) %>
             </dd>
           <% end %>
         </dl>

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -11,15 +11,6 @@
             <a href="/search?erb=expiring" class="quick-filters__filter quick-filters__filter--expiring">
                 Studies with ERB approval expiring
             </a>
-          <% if @include_archived %>
-            <a href="?include_archived=0" class="quick-filters__filter quick-filters__filter--archived">
-                Exclude archived studies
-            </a>
-          <% else %>
-            <a href="?include_archived=1" class="quick-filters__filter quick-filters__filter--archived">
-                Include archived studies
-            </a>
-          <% end %>
         </div>
     </div>
     <div class="list-of-things__secondary-action list-of-things__secondary-action--filters">
@@ -29,7 +20,11 @@
               <select name="study_stage">
                   <option value="">All stages</option>
                   <% Study::STUDY_STAGE_LABELS.each do |k, v| %>
-                    <option value="<%= k %>" <%= "selected" if k.to_s == @study_stage %>><%= v %></option>
+                    <% unless k == :archived || k == :withdrawn_postponed %>
+                        <option value="<%= k %>" <%= "selected" if k.to_s == @study_stage %>>
+                            <%= v %>
+                        </option>
+                    <% end %>
                   <% end %>
               </select>
           </p>
@@ -60,6 +55,16 @@
                     <option value="<%= t.name.downcase %>" <%= "selected" if t.name.downcase == @study_type %>><%= t.name %></option>
                   <% end %>
               </select>
+          </p>
+          <p>
+              <label for="include_archived">
+                <input id="include_archived"
+                       type="checkbox"
+                       value="1"
+                       name="include_archived"
+                       <%= "checked" if @include_archived %>>
+                Include archived studies?
+              </label>
           </p>
           <p>
             <input type="hidden" name="q" value="<%= @q %>" />

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -63,6 +63,7 @@
           </p>
           <p>
             <input type="hidden" name="q" value="<%= @q %>" />
+            <input type="hidden" name="order" value="<%= params[:order] %>" />
             <button type="submit" class="btn btn-success">
                 Filter
             </button>

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -23,30 +23,35 @@
         </div>
     </div>
     <div class="list-of-things__secondary-action list-of-things__secondary-action--filters">
-        <p>
-            <label>Stage:</label>
-            <select>
-                <option>All stages</option>
-            </select>
-        </p>
-        <p>
-            <label>Location:</label>
-            <select>
-                <option>All locations</option>
-            </select>
-        </p>
-        <p>
-            <label>Topic:</label>
-            <select>
-                <option>All topics</option>
-            </select>
-        </p>
-        <p>
-            <label>Methodology:</label>
-            <select>
-                <option>All methodologies</option>
-            </select>
-        </p>
+        <form method="get" action="/search">
+          <p>
+              <label>Stage:</label>
+              <select>
+                  <option>All stages</option>
+              </select>
+          </p>
+          <p>
+              <label>Location:</label>
+              <select>
+                  <option>All locations</option>
+              </select>
+          </p>
+          <p>
+              <label>Topic:</label>
+              <select>
+                  <option>All topics</option>
+              </select>
+          </p>
+          <p>
+              <label>Methodology:</label>
+              <select name="study_type">
+                  <option value="">All methodologies</option>
+                  <% @study_types.each do |t| %>
+                    <option value="<%= t.name.downcase %>"><%= t.name %></option>
+                  <% end %>
+              </select>
+          </p>
+        </form>
     </div>
     <a href="/export" class="list-of-things__secondary-action list-of-things__secondary-action--download">
         Download this page as a CSV for Excel

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -26,8 +26,11 @@
         <form method="get" action="/search">
           <p>
               <label>Stage:</label>
-              <select>
-                  <option>All stages</option>
+              <select name="study_stage">
+                  <option value="">All stages</option>
+                  <% Study::STUDY_STAGE_LABELS.each do |k, v| %>
+                    <option value="<%= k %>" <%= "selected" if k.to_s == @study_stage %>><%= v %></option>
+                  <% end %>
               </select>
           </p>
           <p>
@@ -47,9 +50,14 @@
               <select name="study_type">
                   <option value="">All methodologies</option>
                   <% @study_types.each do |t| %>
-                    <option value="<%= t.name.downcase %>"><%= t.name %></option>
+                    <option value="<%= t.name.downcase %>" <%= "selected" if t.name.downcase == @study_type %>><%= t.name %></option>
                   <% end %>
               </select>
+          </p>
+          <p>
+            <button type="submit" class="btn btn-success">
+                Filter
+            </button>
           </p>
         </form>
     </div>

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -62,6 +62,7 @@
               </select>
           </p>
           <p>
+            <input type="hidden" name="q" value="<%= @q %>" />
             <button type="submit" class="btn btn-success">
                 Filter
             </button>

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -23,7 +23,7 @@
         </div>
     </div>
     <div class="list-of-things__secondary-action list-of-things__secondary-action--filters">
-        <form method="get" action="/search">
+        <form method="get" action="">
           <p>
               <label>Stage:</label>
               <select name="study_stage">

--- a/app/views/shared/_list_of_things_sidebar.html.erb
+++ b/app/views/shared/_list_of_things_sidebar.html.erb
@@ -35,14 +35,21 @@
           </p>
           <p>
               <label>Location:</label>
-              <select>
-                  <option>All locations</option>
+              <select name="country">
+                  <option value="">All locations</option>
+                  <% @countries.keys.sort.each do |name| %>
+                    <% code = @countries[name] %>
+                    <option value="<%= code %>" <%= "selected" if code == @country %>><%= name %></option>
+                  <% end %>
               </select>
           </p>
           <p>
               <label>Topic:</label>
-              <select>
-                  <option>All topics</option>
+              <select name="study_topic">
+                  <option value="">All topics</option>
+                  <% @study_topics.each do |t| %>
+                    <option value="<%= t.name.downcase %>" <%= "selected" if t.name.downcase == @study_topic %>><%= t.name %></option>
+                  <% end %>
               </select>
           </p>
           <p>

--- a/app/views/shared/_list_of_things_sorting.html.erb
+++ b/app/views/shared/_list_of_things_sorting.html.erb
@@ -1,16 +1,18 @@
-<form method="get" class="list-of-things__sorting">
-  <%= page_entries_info @studies, entry_name: "study" %> by
-  <select name="order">
-      <option value="updated" <%= "selected" if params[:order] == "updated" %>>most recently updated</option>
-      <option value="created" <%= "selected" if params[:order] == "created" %>>most recently created</option>
-  </select>
-  <input type="hidden" name="q" value="<%= @q %>" />
-  <input type="hidden" name="study_stage" value="<%= @study_stage %>" />
-  <input type="hidden" name="country" value="<%= @country %>" />
-  <input type="hidden" name="study_type" value="<%= @study_type %>" />
-  <input type="hidden" name="study_topic" value="<%= @study_topic %>" />
-  <input type="hidden" name="include_archived" value="<%= "1" if @include_archived %>" />
-  <button type="submit" class="btn btn-success">
-      Go
-  </button>
-</form>
+<% if @studies.any? %>
+  <form method="get" class="list-of-things__sorting">
+    <%= page_entries_info @studies, entry_name: "study" %> by
+    <select name="order">
+        <option value="updated" <%= "selected" if params[:order] == "updated" %>>most recently updated</option>
+        <option value="created" <%= "selected" if params[:order] == "created" %>>most recently created</option>
+    </select>
+    <input type="hidden" name="q" value="<%= @q %>" />
+    <input type="hidden" name="study_stage" value="<%= @study_stage %>" />
+    <input type="hidden" name="country" value="<%= @country %>" />
+    <input type="hidden" name="study_type" value="<%= @study_type %>" />
+    <input type="hidden" name="study_topic" value="<%= @study_topic %>" />
+    <input type="hidden" name="include_archived" value="<%= "1" if @include_archived %>" />
+    <button type="submit" class="btn btn-success">
+        Go
+    </button>
+  </form>
+<% end %>

--- a/app/views/shared/_list_of_things_sorting.html.erb
+++ b/app/views/shared/_list_of_things_sorting.html.erb
@@ -9,6 +9,7 @@
   <input type="hidden" name="country" value="<%= @country %>" />
   <input type="hidden" name="study_type" value="<%= @study_type %>" />
   <input type="hidden" name="study_topic" value="<%= @study_topic %>" />
+  <input type="hidden" name="include_archived" value="<%= "1" if @include_archived %>" />
   <button type="submit" class="btn btn-success">
       Go
   </button>

--- a/app/views/shared/_list_of_things_sorting.html.erb
+++ b/app/views/shared/_list_of_things_sorting.html.erb
@@ -1,7 +1,15 @@
-<p class="list-of-things__sorting">
-    <%= page_entries_info @studies, entry_name: "study" %> by
-    <select>
-        <option selected>most recently updated</option>
-        <option>most recently created</option>
-    </select>
-</p>
+<form method="get" class="list-of-things__sorting">
+  <%= page_entries_info @studies, entry_name: "study" %> by
+  <select name="order">
+      <option value="updated" <%= "selected" if params[:order] == "updated" %>>most recently updated</option>
+      <option value="created" <%= "selected" if params[:order] == "created" %>>most recently created</option>
+  </select>
+  <input type="hidden" name="q" value="<%= @q %>" />
+  <input type="hidden" name="study_stage" value="<%= @study_stage %>" />
+  <input type="hidden" name="country" value="<%= @country %>" />
+  <input type="hidden" name="study_type" value="<%= @study_type %>" />
+  <input type="hidden" name="study_topic" value="<%= @study_topic %>" />
+  <button type="submit" class="btn btn-success">
+      Go
+  </button>
+</form>

--- a/app/views/studies/_header_primary.html.erb
+++ b/app/views/studies/_header_primary.html.erb
@@ -6,7 +6,7 @@
         <div>
             <h3 class="study-header__details__key">Methodology</h3>
             <p class="study-header__details__value">
-              <%= link_to @study.study_type.name, search_path(study_type: @study.study_type.name.downcase) %>
+              <%= link_to @study.study_type.name, search_path(study_type: @study.study_type.name) %>
             </p>
         </div>
         <div>
@@ -15,7 +15,7 @@
             </h3>
             <p class="study-header__details__value">
                 <% @study.study_topics.each do |study_topic| %>
-                  <%= link_to study_topic.name, search_path(study_topic: study_topic.name.downcase) %><%= "," unless study_topic == @study.study_topics.last %>
+                  <%= link_to study_topic.name, search_path(study_topic: study_topic.name) %><%= "," unless study_topic == @study.study_topics.last %>
                 <% end %>
             </p>
         </div>
@@ -23,7 +23,7 @@
         <div>
             <h3 class="study-header__details__key">Principal investigator</h3>
             <p class="study-header__details__value">
-              <%= link_to @study.principal_investigator.name, search_path(q: @study.principal_investigator.name.downcase) %>
+              <%= link_to @study.principal_investigator.name, search_path(q: @study.principal_investigator.name) %>
             </p>
         </div>
       <% end %>

--- a/app/views/studies/_header_primary.html.erb
+++ b/app/views/studies/_header_primary.html.erb
@@ -5,25 +5,25 @@
     <div class="study-header__details">
         <div>
             <h3 class="study-header__details__key">Methodology</h3>
-            <p class="study-header__details__value"><a href="/search?methodology=mixed%20methods%20study"><%= @study.study_type.name %></a></p>
+            <p class="study-header__details__value">
+              <%= link_to @study.study_type.name, search_path(study_type: @study.study_type.name.downcase) %>
+            </p>
         </div>
         <div>
             <h3 class="study-header__details__key">
                 <%= "Topic".pluralize(@study.study_topics.count) %>
             </h3>
             <p class="study-header__details__value">
-                <a href="/search?topic=tuberculosis">
-                    <%= @study.study_topic_names %>
-                </a>
+                <% @study.study_topics.each do |study_topic| %>
+                  <%= link_to study_topic.name, search_path(study_topic: study_topic.name.downcase) %><%= "," unless study_topic == @study.study_topics.last %>
+                <% end %>
             </p>
         </div>
       <% unless @study.principal_investigator.blank? %>
         <div>
             <h3 class="study-header__details__key">Principal investigator</h3>
             <p class="study-header__details__value">
-                <a href="/search?pi=janet%20bloggs">
-                    <%= @study.principal_investigator.name %>
-                </a>
+              <%= link_to @study.principal_investigator.name, search_path(pi: @study.principal_investigator.name.downcase) %>
             </p>
         </div>
       <% end %>
@@ -33,9 +33,9 @@
                 <%= "Location".pluralize(@study.countries.count) %>
             </h3>
             <p class="study-header__details__value">
-                <a href="/search?location=south%20sudan">
-                    <%= @study.country_names %>
-                </a>
+              <% @study.countries.each do |country| %>
+                <%= link_to country.name, search_path(country: country.alpha2) %><%= "," unless country == @study.countries.last %>
+              <% end %>
             </p>
         </div>
       <% end %>

--- a/app/views/studies/_header_primary.html.erb
+++ b/app/views/studies/_header_primary.html.erb
@@ -23,7 +23,7 @@
         <div>
             <h3 class="study-header__details__key">Principal investigator</h3>
             <p class="study-header__details__value">
-              <%= link_to @study.principal_investigator.name, search_path(pi: @study.principal_investigator.name.downcase) %>
+              <%= link_to @study.principal_investigator.name, search_path(q: @study.principal_investigator.name.downcase) %>
             </p>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,5 +24,5 @@ Rails.application.routes.draw do
     resources :studies, only: :index
   end
 
-  get '/search', :to => "search#index"
+  get "/search", to: "search#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,4 +23,6 @@ Rails.application.routes.draw do
   resources :users, only: []  do
     resources :studies, only: :index
   end
+
+  get '/search', :to => "search#index"
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require "support/study_listing_controller_shared_examples"
+
+RSpec.describe SearchController, type: :controller do
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+
+    context "when there are some studies" do
+      let!(:studies) { FactoryGirl.create_list(:study, 20) }
+      let(:action) { :index }
+      let(:params) { {} }
+
+      it_behaves_like "study listing controller"
+    end
+  end
+end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -15,5 +15,39 @@ RSpec.describe SearchController, type: :controller do
 
       it_behaves_like "study listing controller"
     end
+
+    context "searching by various fields" do
+      before do
+        topic = StudyTopic.find_by_name("Brucellosis") ||
+                FactoryGirl.create(:brucellosis)
+        pi = FactoryGirl.create(:user, name: "Barry Einstein")
+        @study = FactoryGirl.create(:study,
+                  country_codes: ['ZW'],
+                  title: "water sanitation study",
+                  study_topics: [topic],
+                  principal_investigator: pi
+                )
+      end
+
+      it "allows searching by title" do
+        get :index, { q: "sanitation" }
+        expect(assigns[:studies]).to include @study
+      end
+
+      it "allows searching by PI name" do
+        get :index, { q: "einstein" }
+        expect(assigns[:studies]).to include @study
+      end
+
+      it "allows searching by topic" do
+        get :index, { q: "brucellosis" }
+        expect(assigns[:studies]).to include @study
+      end
+
+      it "allows searching by country" do
+        get :index, { q: "zimbabwe" }
+        expect(assigns[:studies]).to include @study
+      end
+    end
   end
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -21,31 +21,37 @@ RSpec.describe SearchController, type: :controller do
         topic = StudyTopic.find_by_name("Brucellosis") ||
                 FactoryGirl.create(:brucellosis)
         pi = FactoryGirl.create(:user, name: "Barry Einstein")
-        @study = FactoryGirl.create(:study,
-                  country_codes: ['ZW'],
-                  title: "water sanitation study",
-                  study_topics: [topic],
-                  principal_investigator: pi
-                )
+        @study = FactoryGirl.create(
+          :study,
+          reference_number: "OCA12-34",
+          country_codes: ["ZW"],
+          title: "water sanitation study",
+          study_topics: [topic],
+          principal_investigator: pi)
       end
 
       it "allows searching by title" do
-        get :index, { q: "sanitation" }
+        get :index, q: "sanitation"
         expect(assigns[:studies]).to include @study
       end
 
       it "allows searching by PI name" do
-        get :index, { q: "einstein" }
+        get :index, q: "einstein"
         expect(assigns[:studies]).to include @study
       end
 
       it "allows searching by topic" do
-        get :index, { q: "brucellosis" }
+        get :index, q: "brucellosis"
         expect(assigns[:studies]).to include @study
       end
 
       it "allows searching by country" do
-        get :index, { q: "zimbabwe" }
+        get :index, q: "zimbabwe"
+        expect(assigns[:studies]).to include @study
+      end
+
+      it "allows searching by reference number" do
+        get :index, q: "OCA12-34"
         expect(assigns[:studies]).to include @study
       end
     end

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -613,6 +613,13 @@ RSpec.describe Study, type: :model do
                                  completed: archive_date + 1.day,
                                  protocol_needed: false)
     end
+    let!(:completed_but_not_in_right_stage) do
+      # Some of the existing data has a completion date but the study is still
+      # marked as being in delivery
+      FactoryGirl.create(:study, study_stage: :delivery,
+                                 completed: archive_date - 1.day,
+                                 protocol_needed: false)
+    end
     let!(:not_archived) do
       # Make one of every other stage to check they're excluded too
       stages = Study.study_stages.keys
@@ -624,6 +631,7 @@ RSpec.describe Study, type: :model do
       end
       not_archived << on_archive_date
       not_archived << younger_than_archive_date
+      not_archived << completed_but_not_in_right_stage
       not_archived
     end
 

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -917,4 +917,19 @@ RSpec.describe Study, type: :model do
       end
     end
   end
+
+  describe "#in_country" do
+    let(:uk_study) { FactoryGirl.create(:study, country_codes: ["GB"]) }
+    let(:bd_study) { FactoryGirl.create(:study, country_codes: ["BD"]) }
+    let(:bd_and_uk_study) do
+      FactoryGirl.create(:study, country_codes: %w(BD GB))
+    end
+
+    it "lists studies in the given country" do
+      uk_expected = [uk_study, bd_and_uk_study]
+      expect(Study.in_country("GB")).to match_array(uk_expected)
+      bd_expected = [bd_study, bd_and_uk_study]
+      expect(Study.in_country("BD")).to match_array(bd_expected)
+    end
+  end
 end

--- a/spec/support/study_listing_controller_shared_examples.rb
+++ b/spec/support/study_listing_controller_shared_examples.rb
@@ -49,19 +49,16 @@ RSpec.shared_examples_for "study listing controller" do
 
   describe "#set_filter_form_values" do
     let(:modelling_type) { FactoryGirl.create(:modelling_type) }
-    let(:modelling_study) {
+    let(:modelling_study) do
       FactoryGirl.create(:study, study_type: modelling_type)
-    }
-    let(:modelling_completion_study) {
-      FactoryGirl.create(:study,
-        study_type: modelling_type,
-        study_stage: :completion,
-        protocol_needed: false)
-    }
+    end
+    let(:modelling_completion_study) do
+      FactoryGirl.create(:study, study_type: modelling_type,
+                                 study_stage: :completion,
+                                 protocol_needed: false)
+    end
 
     context "when no filters are applied" do
-      # let(:params) { {} }
-
       it "sets nil filter values" do
         get action, params
         expect(assigns[:study_type]).to be nil
@@ -81,14 +78,14 @@ RSpec.shared_examples_for "study listing controller" do
     end
 
     context "when filters are applied" do
-      let(:extra_params) {
-        {study_type: 'modelling', study_stage: 'completion'}
-      }
+      let(:extra_params) do
+        { study_type: "modelling", study_stage: "completion" }
+      end
 
       it "sets correct filter values" do
         get action, params.merge(extra_params)
-        expect(assigns[:study_type]).to eq 'modelling'
-        expect(assigns[:study_stage]).to eq 'completion'
+        expect(assigns[:study_type]).to eq "modelling"
+        expect(assigns[:study_stage]).to eq "completion"
       end
 
       it "shows only matching studies" do
@@ -113,18 +110,18 @@ RSpec.shared_examples_for "study listing controller" do
     before do
       Study.destroy_all
       # Created a long time ago, updated recently
-      @study1 = FactoryGirl.create(:study,
+      @study1 = FactoryGirl.create(
+        :study,
         updated_at: 1.week.ago,
         created_at: 6.months.ago,
-        principal_investigator_id: params[:user_id]
-      )
+        principal_investigator_id: params[:user_id])
       # Created and updated a short while ago,
       # i.e. between the created/updated dates of @study1
-      @study2 = FactoryGirl.create(:study,
+      @study2 = FactoryGirl.create(
+        :study,
         updated_at: 3.months.ago,
         created_at: 3.months.ago,
-        principal_investigator_id: params[:user_id]
-      )
+        principal_investigator_id: params[:user_id])
     end
 
     it "defaults to ordering by most recently updated" do
@@ -134,13 +131,13 @@ RSpec.shared_examples_for "study listing controller" do
     end
 
     it "can be ordered by updated_at" do
-      get action, params.merge(order: 'updated')
+      get action, params.merge(order: "updated")
       expect(assigns[:studies].first).to eq @study1
       expect(assigns[:studies].last).to eq @study2
     end
 
     it "can be ordered by created_at" do
-      get action, params.merge(order: 'created')
+      get action, params.merge(order: "created")
       expect(assigns[:studies].first).to eq @study2
       expect(assigns[:studies].last).to eq @study1
     end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "home/index.html.erb", type: :view do
     # The view expects to be able to paginate the the list of studies
     @studies = Kaminari.paginate_array(@studies).page(1).per(10)
     assign(:studies, @studies)
+    @study_types = []
     render
   end
 

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "home/index.html.erb", type: :view do
     @studies = Kaminari.paginate_array(@studies).page(1).per(10)
     assign(:studies, @studies)
     @study_types = []
+    @study_topics = []
+    @countries = {}
     render
   end
 
@@ -42,7 +44,8 @@ RSpec.describe "home/index.html.erb", type: :view do
     @studies.first.country_codes = %w(GB BD)
     @studies.first.save!
     render
-    expect(rendered).to match(/United Kingdom and Bangladesh/)
+    expect(rendered).to match(/United Kingdom/)
+    expect(rendered).to match(/Bangladesh/)
   end
 
   context "when the user is logged in" do

--- a/spec/views/studies/show.html.erb_spec.rb
+++ b/spec/views/studies/show.html.erb_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe "studies/show.html.erb", type: :view do
     study.country_codes = %w(GB BD)
     study.save!
     render
-    expect(rendered).to match(/United Kingdom and Bangladesh/)
+    expect(rendered).to match(/United Kingdom/)
+    expect(rendered).to match(/Bangladesh/)
   end
 
   it "shows the pi when there is one" do


### PR DESCRIPTION
This PR:

 - Wires up the ordering dropdown and filters on the right-hand side of study lists (e.g. homepage, search page, user study dashboard)
 - Allows the search field in the header to be used for searching by PI name, study title, country or topic
 - Also generates proper links to search page in study detail header and search result entries

For #1