### PR TITLE
Flag studies which need attention

### DIFF
--- a/app/assets/stylesheets/_shared.scss
+++ b/app/assets/stylesheets/_shared.scss
@@ -57,3 +57,7 @@ body {
     padding-left: 0 !important; // Override ridiculously long selector in bootstrap-select.scss
   }
 }
+
+.badge--red {
+  background-color: $color-red;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,5 +7,8 @@ class HomeController < ApplicationController
                                     page(params[:page]).
                                     per(10)
     # rubocop:enable Style/MultilineOperationIndentation
+    unless current_user.blank?
+      @flagged_studies_count = current_user.studies.flagged.count
+    end
   end
 end

--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -15,6 +15,8 @@ class StudiesController < ApplicationController
                                     page(page).
                                     per(10)
     # rubocop:enable Style/MultilineOperationIndentation
+    @flagged_studies_count = @user.studies.flagged.count
+    @show_flagged = true
     render "home/index"
   end
 

--- a/app/views/shared/_list_of_things.html.erb
+++ b/app/views/shared/_list_of_things.html.erb
@@ -4,27 +4,32 @@
       <% if @studies.each do |study| %>
         <div class="list-of-things__list__item list-of-things__list__item--study">
             <p class="list-of-things__list__item__badge list-of-things__list__item__badge--completed"><%= study.study_stage_label %></p>
-        <h2 class="list-of-things__list__item__title">
-            <a href="<%= study_path study %>"><%= study.title %></a>
-        </h2>
-        <dl class="dl-horizontal">
-            <dt>Study details</dt>
-            <dd>
-                <%= link_to study.study_type.name, search_path(study_type: study.study_type.name) %>
-              <% unless study.country_names.blank? %>
-                in
-                <% study.countries.each do |country| %>
-                  <%= link_to country.name, search_path(country: country.alpha2) %><%= "," unless country == study.countries.last %>
-                <% end %>
-              <% end %>
-            </dd>
-          <% unless study.principal_investigator.blank? %>
-            <dt>Principal investigator:</dt>
-            <dd>
-                <%= link_to study.principal_investigator.name, search_path(q: study.principal_investigator.name) %>
-            </dd>
+          <% if @show_flagged && study.flagged? %>
+            &nbsp;<span class="badge badge--red">
+                <span class="glyphicon glyphicon-flag"></span>
+            </span>
           <% end %>
-        </dl>
+            <h2 class="list-of-things__list__item__title">
+                <a href="<%= study_path study %>"><%= study.title %></a>
+            </h2>
+            <dl class="dl-horizontal">
+                <dt>Study details</dt>
+                <dd>
+                    <%= link_to study.study_type.name, search_path(study_type: study.study_type.name) %>
+                  <% unless study.country_names.blank? %>
+                    in
+                    <% study.countries.each do |country| %>
+                      <%= link_to country.name, search_path(country: country.alpha2) %><%= "," unless country == study.countries.last %>
+                    <% end %>
+                  <% end %>
+                </dd>
+              <% unless study.principal_investigator.blank? %>
+                <dt>Principal investigator:</dt>
+                <dd>
+                    <%= link_to study.principal_investigator.name, search_path(q: study.principal_investigator.name) %>
+                </dd>
+              <% end %>
+            </dl>
         </div>
       <% end.empty? %>
         <div class="list-of-things__list__item list-of-things__list__item--study">

--- a/app/views/shared/_subnav.html.erb
+++ b/app/views/shared/_subnav.html.erb
@@ -12,6 +12,9 @@
                 <a href="<%= user_studies_path(current_user) %>"
                    class="<%= "active" if current_page?(user_studies_path(current_user)) %>">
                     Your studies
+                    <% if @flagged_studies_count > 0 %>
+                        <span class="badge badge--red"><%= @flagged_studies_count %></span>
+                    <% end %>
                 </a>
             </li>
             <li>

--- a/app/views/studies/_header_primary.html.erb
+++ b/app/views/studies/_header_primary.html.erb
@@ -1,6 +1,13 @@
 <div class="study-header__primary">
     <div class="site-header__title">
-        <h1><%= @study.title %></h1>
+        <h1>
+            <%= @study.title %>
+          <% if @study.user_can_manage?(current_user) %>
+            <span class="badge badge--red">
+                <span class="glyphicon glyphicon-flag"></span>
+            </span>
+          <% end %>
+        </h1>
     </div>
     <div class="study-header__details">
         <div>

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 require "support/study_listing_controller_shared_examples"
+require "support/devise"
 
 RSpec.describe HomeController, type: :controller do
   describe "GET #index" do
@@ -14,6 +15,22 @@ RSpec.describe HomeController, type: :controller do
       let(:params) { {} }
 
       it_behaves_like "study listing controller"
+    end
+
+    context "when a user is logged in" do
+      it "sets flagged_studies_count" do
+        user = FactoryGirl.create(:user)
+        FactoryGirl.create(
+          :study,
+          study_stage: :delivery,
+          protocol_needed: false,
+          expected_completion_date: Time.zone.today - 1.day,
+          completed: nil,
+          principal_investigator: user)
+        sign_in user
+        get :index
+        expect(assigns[:flagged_studies_count]).to eq 1
+      end
     end
   end
 end

--- a/spec/controllers/studies_controller_spec.rb
+++ b/spec/controllers/studies_controller_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe StudiesController, type: :controller do
       expect(response).to render_template("home/index")
     end
 
+    it "sets @show_flagged" do
+      expect(assigns[:show_flagged]).to be true
+    end
+
     context "when the user has some studies" do
       let!(:studies) do
         FactoryGirl.create_list(:study, 20, principal_investigator: user)
@@ -46,6 +50,18 @@ RSpec.describe StudiesController, type: :controller do
       let(:params) { { user_id: user.id } }
 
       it_behaves_like "study listing controller"
+
+      it "sets @flagged_studies_count" do
+        FactoryGirl.create(
+          :study,
+          study_stage: :delivery,
+          protocol_needed: false,
+          expected_completion_date: Time.zone.today - 1.day,
+          completed: nil,
+          principal_investigator: user)
+        get action, params
+        expect(assigns[:flagged_studies_count]).to eq 1
+      end
     end
 
     describe "access control" do

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "home/index.html.erb", type: :view do
     @study_types = []
     @study_topics = []
     @countries = {}
+    assign(:flagged_studies_count, 0)
     render
   end
 


### PR DESCRIPTION
This adds some methods to tell if a particular study "needs attention" and
updates the study dashboard and study pages to display that if so.

@zarino - I've used bootstrap's built in badges and icons at the moment, but
you might want to take a look at the screenshots and see if there's anything
more you'd like to do with this?

![screen shot 2016-02-22 at 12 10 20](https://cloud.githubusercontent.com/assets/663700/13217871/93e6c7ea-d95d-11e5-8486-fb2a429d6796.png)

![screen shot 2016-02-22 at 10 07 49](https://cloud.githubusercontent.com/assets/663700/13217874/98c9c960-d95d-11e5-8cdd-d88f5b114af5.png)

Closes #17