### PR TITLE
Add a button to send requests for annual updates

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -7,6 +7,9 @@ ActiveAdmin.register_page "Dashboard" do
   action_item :request_delivery_updates do
     link_to "Request delivery updates", admin_request_delivery_updates_path
   end
+  action_item :request_delivery_updates do
+    link_to "Request annual updates", admin_request_annual_updates_path
+  end
 
   content title: proc { I18n.t("active_admin.dashboard") } do
     columns do

--- a/app/admin/request_annual_updates.rb
+++ b/app/admin/request_annual_updates.rb
@@ -1,0 +1,50 @@
+ActiveAdmin.register_page "Request annual updates" do
+  page_action :send_requests, method: :post do
+    # We're going to create lots of invites, but they send an email on save
+    # and we only want to send one email per user, so turn off the callbacks
+    StudyInvite.skip_callback(:save, :after, :send_invite)
+    User.all.each do |user|
+      next unless user.principal_investigator_studies.active.any?
+      # Create invites for each study so that we can direct users to the
+      # impact adding form directly
+      invites = []
+      user.principal_investigator_studies.active.each do |study|
+        invites << StudyInvite.create(study: study,
+                                      invited_user: user,
+                                      inviting_user: current_user)
+      end
+      AnnualUpdateMailer.invite(user, invites).deliver_now
+    end
+    # Turn the callbacks back on
+    StudyInvite.set_callback(:save, :after, :send_invite)
+    redirect_to admin_request_annual_updates_path, notice: "Requests sent!"
+  end
+
+  action_item :send_request_updates do
+    count = 0
+    User.all.each do |user|
+      next unless user.principal_investigator_studies.active.any?
+      count += 1
+    end
+    path = admin_request_annual_updates_send_requests_path
+    link_to(path, method: :post) do
+      "Send #{pluralize(count, 'annual update request')}"
+    end
+  end
+
+  content title: "Request annual updates" do
+    h2 do
+      "The following PIs will be asked for annual updates on their" \
+      " active studies:"
+    end
+    ul do
+      User.all.each do |user|
+        next unless user.principal_investigator_studies.active.any?
+        count = user.principal_investigator_studies.active.count
+        li do
+          "#{user.name} (#{user.email}) - #{pluralize(count, 'study')}"
+        end
+      end
+    end
+  end
+end

--- a/app/mailers/annual_update_mailer.rb
+++ b/app/mailers/annual_update_mailer.rb
@@ -1,0 +1,8 @@
+class AnnualUpdateMailer < ApplicationMailer
+  def invite(user, invites)
+    @studies = user.principal_investigator_studies.active
+    @invites = invites
+    @user = user
+    mail to: @user.email
+  end
+end

--- a/app/views/annual_update_mailer/invite.text.erb
+++ b/app/views/annual_update_mailer/invite.text.erb
@@ -1,0 +1,19 @@
+<% message.subject = "It's time to submit your annual #{'update'.pluralize(@studies.count)} on ReMIT" %>
+Hi <%= @user.name %>,
+
+It's time to submit your annual <%= "update".pluralize(@studies.count) %> on ReMIT.
+
+You can access all your studies on your dashboard:
+
+<%= user_studies_url(@user) %>
+
+Or, if you want to go straight to adding impact directly, you can use these
+links:
+
+<% @invites.each do |invite| %>
+<%= invite.study.reference_number %> - <%= "#{study_outputs_new_url(invite.study)}?token=#{@user.invite_token}" %>
+<% end %>
+
+Many thanks,
+
+MSF ReMIT team.

--- a/spec/features/admin/request_annual_updates_spec.rb
+++ b/spec/features/admin/request_annual_updates_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+require "support/helpers/features/user_accounts"
+
+RSpec.describe "RequestAnnualUpdates" do
+  let!(:admin_user) { FactoryGirl.create(:admin_user) }
+  let!(:user1) { FactoryGirl.create(:user, id: 997) }
+  let!(:user2) { FactoryGirl.create(:user, id: 998) }
+  let!(:user3) { FactoryGirl.create(:user, id: 999) }
+  let!(:study1) do
+    FactoryGirl.create(:study, principal_investigator: user1,
+                               study_stage: :delivery,
+                               protocol_needed: false)
+  end
+  let!(:study2) do
+    FactoryGirl.create(:study, principal_investigator: user1,
+                               study_stage: :delivery,
+                               protocol_needed: false)
+  end
+  let!(:study3) { FactoryGirl.create(:study, principal_investigator: user1) }
+  let!(:study4) do
+    FactoryGirl.create(:study, principal_investigator: user2,
+                               study_stage: :delivery,
+                               protocol_needed: false)
+  end
+  let!(:study5) { FactoryGirl.create(:study, principal_investigator: user3) }
+
+  before do
+    # Clear out emails for new users etc before our tests
+    ActionMailer::Base.deliveries = []
+  end
+
+  it "allows you to send annual update emails" do
+    sign_in_account(admin_user.email)
+    within "#title_bar" do
+      click_link "Request annual updates"
+    end
+
+    expect(page).to have_text("#{user1.name} (#{user1.email}) - 2 studies")
+    expect(page).to have_text("#{user2.name} (#{user2.email}) - 1 study")
+    expect(page).not_to have_text("#{user3.name} (#{user3.email}) - 1 study")
+
+    click_link "Send 2 annual update requests"
+
+    expect(page).to have_text("Requests sent!")
+
+    # Check no extra study invite mails have been sent
+    expect(ActionMailer::Base.deliveries.count).to eq 2
+
+    first_mail = ActionMailer::Base.deliveries.first
+    second_mail = ActionMailer::Base.deliveries.second
+
+    expect(first_mail.to).to eq [user1.email]
+    expect(second_mail.to).to eq [user2.email]
+
+    expect(first_mail.body.to_s).to(
+      have_text(user_studies_url(user1)))
+    expect(first_mail.body.to_s).to(
+      have_text(study_outputs_new_url(study1)))
+    expect(first_mail.body.to_s).to(
+      have_text(study_outputs_new_url(study2)))
+
+    expect(second_mail.body.to_s).to(
+      have_text(user_studies_url(user2)))
+    expect(second_mail.body.to_s).to(
+      have_text(study_outputs_new_url(study4)))
+  end
+end

--- a/spec/fixtures/annual_update_mailer/invite.txt
+++ b/spec/fixtures/annual_update_mailer/invite.txt
@@ -1,0 +1,17 @@
+Hi Test User,
+
+It's time to submit your annual updates on ReMIT.
+
+You can access all your studies on your dashboard:
+
+http://www.example.com/users/999/studies
+
+Or, if you want to go straight to adding impact directly, you can use these
+links:
+
+ABC123 - http://www.example.com/studies/1/outputs/new?token=invite-token
+ABC124 - http://www.example.com/studies/2/outputs/new?token=invite-token
+
+Many thanks,
+
+MSF ReMIT team.

--- a/spec/mailers/annual_update_mailer_spec.rb
+++ b/spec/mailers/annual_update_mailer_spec.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+require "rails_helper"
+
+RSpec.describe AnnualUpdateMailer, type: :mailer do
+  describe "#invite" do
+    let(:user) do
+      FactoryGirl.create(:user, name: "Test User",
+                                email: "iw@example.com",
+                                id: 999,
+                                invite_token: "invite-token")
+    end
+    let(:active_study1) do
+      FactoryGirl.create(:study, study_stage: "delivery",
+                                 protocol_needed: false,
+                                 reference_number: "ABC123",
+                                 id: 1)
+    end
+    let(:active_study2) do
+      FactoryGirl.create(:study, study_stage: "delivery",
+                                 protocol_needed: false,
+                                 reference_number: "ABC124",
+                                 id: 2)
+    end
+    let(:inactive_study) do
+      FactoryGirl.create(:study, study_stage: "concept")
+    end
+    let(:invite1) do
+      FactoryGirl.create(:study_invite, study: active_study1,
+                                        invited_user: user)
+    end
+    let(:invite2) do
+      FactoryGirl.create(:study_invite, study: active_study2,
+                                        invited_user: user)
+    end
+    let(:invites) { [invite1, invite2] }
+
+    let(:mail) { AnnualUpdateMailer.invite(user, invites) }
+
+    it "sends to the users email address" do
+      expect(mail.to.first).to eq user.email
+    end
+
+    it "sets the subject" do
+      expected_subject = "It's time to submit your annual updates on ReMIT"
+      expect(mail.subject).to eq expected_subject
+    end
+
+    it "has the right body" do
+      fixture = Rails.root.join("spec",
+                                "fixtures",
+                                "annual_update_mailer",
+                                "invite.txt")
+      expect(IO.readlines(fixture).join).to eq mail.body.to_s
+    end
+  end
+end


### PR DESCRIPTION
This adds an big button to the admin homepage to send emails to all the PIs
with active studies, requesting an annual update. The mailer provides both a
link to their dashboard, and individual impact links for each study.

Closes #150