### PR TITLE
Improve how delayed studies are displayed

### DIFF
--- a/app/assets/stylesheets/_list-of-things.scss
+++ b/app/assets/stylesheets/_list-of-things.scss
@@ -74,15 +74,20 @@
   }
 }
 
-.list-of-things__list__item--attention {
-  .list-of-things__list__item__title a {
-    color: $color-red;
-  }
-
+.list-of-things__list__item--major {
   .list-of-things__list__item__badge {
     background-color: $color-red;
   }
 }
+
+.list-of-things__list__item--minor {
+  .list-of-things__list__item__badge {
+    background-color: $color-bright-orange;
+  }
+}
+
+// There's an option to style .list-of-things__list__item--fine here too, but
+// for now it's left to take the normal colour.
 
 .list-of-things__list__item__badge {
   @extend .label;

--- a/app/models/delivery_update.rb
+++ b/app/models/delivery_update.rb
@@ -54,6 +54,20 @@ class DeliveryUpdate < ActiveRecord::Base
       delayed_statuses.include?(interpretation_and_write_up_status)
   end
 
+  def majorly_delayed?
+    major_statuses = DeliveryUpdateStatus.major_delayed_statuses
+    major_statuses.include?(data_analysis_status) || \
+      major_statuses.include?(data_collection_status) || \
+      major_statuses.include?(interpretation_and_write_up_status)
+  end
+
+  def minorly_delayed?
+    minor_statuses = DeliveryUpdateStatus.minor_delayed_statuses
+    minor_statuses.include?(data_analysis_status) || \
+      minor_statuses.include?(data_collection_status) || \
+      minor_statuses.include?(interpretation_and_write_up_status)
+  end
+
   def update_study
     # We cache whether the most recent delivery_update was delayed on the
     # study model, to make querying by it easier

--- a/app/models/delivery_update_status.rb
+++ b/app/models/delivery_update_status.rb
@@ -39,4 +39,14 @@ class DeliveryUpdateStatus < ActiveRecord::Base
   def self.delayed_statuses
     where(good_medium_bad_or_neutral: %w(medium bad))
   end
+
+  # Which statuses are considered "major" delays
+  def self.major_delayed_statuses
+    where(good_medium_bad_or_neutral: "bad")
+  end
+
+  # Which statuses are considered "minor" delays
+  def self.minor_delayed_statuses
+    where(good_medium_bad_or_neutral: "medium")
+  end
 end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -326,6 +326,36 @@ class Study < ActiveRecord::Base
     erb_submitted < Study.erb_response_overdue_at
   end
 
+  # Exactly how delayed is this study's delivery?
+  # Used to know whether to highlight the delay as "minor" or "major"
+  def delivery_delayed_status
+    if delivery_delayed?
+      if latest_delivery_update.majorly_delayed?
+        return "major"
+      else
+        return "minor"
+      end
+    else
+      # Just in case we're called on a non-delayed study
+      return "fine"
+    end
+  end
+
+  # Exactly how bad is whatever we're flagging this study for?
+  # (see #flagged? for what constitutes being flagged).
+  def flagged_status
+    if flagged?
+      if delivery_delayed?
+        return delivery_delayed_status
+      else
+        return "major"
+      end
+    else
+      # Just in case we're called on a non-flagged study
+      return "fine"
+    end
+  end
+
   def other_study_type_is_set_when_study_type_is_other
     if study_type == StudyType.other_study_type && other_study_type.blank?
       message = "You must describe the study type if you choose " \

--- a/app/views/shared/_list_of_things_study.html.erb
+++ b/app/views/shared/_list_of_things_study.html.erb
@@ -1,7 +1,7 @@
 <div class="list-of-things__list__item
             list-of-things__list__item--study
           <% if @show_flagged && study.flagged? %>
-            list-of-things__list__item--attention
+            list-of-things__list__item--<%= study.flagged_status %>
           <% end %>">
     <p class="list-of-things__list__item__badge
               list-of-things__list__item__badge--<%= study.study_stage %>">


### PR DESCRIPTION
Adds a third colour for statuses (orange) for studies with minor delays, and
reduces the colouring of delayed studies to just the status badge (rather than
the whole title as well).

studies, but they are already only shown on the "your studies" page, so I
don't think anything needs to change there.

Closes #161
Closes #163