### PR TITLE
Don’t bother hiding "Add:" button icons on medium sized screens

### DIFF
--- a/app/assets/stylesheets/_study-main.scss
+++ b/app/assets/stylesheets/_study-main.scss
@@ -24,10 +24,6 @@
       font-size: 0.875em;
       vertical-align: baseline;
       margin-right: 0.3em;
-
-      @media (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
-        display: none;
-      }
     }
   }
 


### PR DESCRIPTION
When there were more buttons in a row, we used to hide the icons. But now there are only 2 buttons, we don’t need to.